### PR TITLE
Icon update

### DIFF
--- a/_includes/silicon-valley/_interaction_area.html
+++ b/_includes/silicon-valley/_interaction_area.html
@@ -5,6 +5,6 @@
 </div>
 
 <div class="secondary-buttons">
-  <button><i class="fas fa-home"></i> <span>Start over</span></button>
+  <button><i class="fas fa-redo"></i> <span>Start over</span></button>
   <button><i class="fas fa-info-circle"></i> <span>More info</span></button>
 </div>

--- a/css/wallscreens/buttons.css
+++ b/css/wallscreens/buttons.css
@@ -26,6 +26,11 @@ button, .button {
   opacity: 0.8;
 }
 
+button .fas,
+.button .fas {
+  color: var(--color-stone-dark);
+}
+
 button .fas:first-child, .button .fas:first-child {
   margin-right: 0.25rem;
 }

--- a/css/wallscreens/styles.css
+++ b/css/wallscreens/styles.css
@@ -15,6 +15,7 @@ body {
   --color-secondary: #dad7cb;
 
   --color-archway-dark: #2F2424;
+  --color-stone-dark: #544948;
 }
 
 pre {
@@ -22,7 +23,6 @@ pre {
   font-size: 1.125rem;
   text-transform: lowercase;
 }
-
 
 
 .wallscreen {


### PR DESCRIPTION
- Updated the icon used for "Start over" to one that makes more sense for that label
- Slightly lightened the color we use for icons

## Before
<img width="454" alt="Screen Shot 2021-10-04 at 4 28 09 PM" src="https://user-images.githubusercontent.com/101482/135937761-2ed770b7-5273-409c-95c8-9fbfd6cf5d00.png">

## After
<img width="454" alt="Screen Shot 2021-10-04 at 4 20 53 PM" src="https://user-images.githubusercontent.com/101482/135937765-9b56164d-f8f8-437a-a256-d9519b2947a6.png">

