### PR TITLE
Swap styles and placement for item caption and note

### DIFF
--- a/_wallscreens/silicon-valley/menuez-slideshow/_slide.html
+++ b/_wallscreens/silicon-valley/menuez-slideshow/_slide.html
@@ -14,11 +14,11 @@
     <h2 class="experience-title">{{ experience.title}}</h2>
 
     <h3 class="item-title">{{ item.title }}</h3>
-    <p class="item-note">{{ item.note }}</p>
+    <p class="item-caption">{{ item.caption }}</p>
     <div class="item-attribution"><span class="item-date">{{ item.date}}</span><span class="separator">•</span><span class="item-creator">{{ item.creator}}</span></div>
     <div class="item-collection"><i>From</i> {{ item.collection }}</div>
 
-    <p class="experience-summary">{{ experience.summary }}</p>
+    <p class="item-note">{{ item.note }}</p>
 
     {% if item.url %}
     <a href="{{ item.url }}" data-qr class="item-url">View catalog record</a>

--- a/_wallscreens/silicon-valley/video-arcades/_slide.html
+++ b/_wallscreens/silicon-valley/video-arcades/_slide.html
@@ -14,11 +14,11 @@
     <h2 class="experience-title">{{ experience.title}}</h2>
 
     <h3 class="item-title">{{ item.title }}</h3>
-    <p class="item-note">{{ item.note }}</p>
+    <p class="item-caption">{{ item.caption }}</p>
     <div class="item-attribution"><span class="item-date">{{ item.date}}</span><span class="separator">•</span><span class="item-creator">{{ item.creator}}</span></div>
     <div class="item-collection"><i>From</i> {{ item.collection }}</div>
 
-    <p class="experience-summary">{{ experience.summary }}</p>
+    <p class="item-note">{{ item.note }}</p>
 
     {% if item.url %}
     <a href="{{ item.url }}" data-qr class="item-url">View catalog record</a>

--- a/css/wallscreens/styles.css
+++ b/css/wallscreens/styles.css
@@ -134,7 +134,7 @@ pre {
   margin-right: 0.7rem;
 }
 
-.item-note {
+.item-caption {
   font-style: italic;
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
Updates to slideshow layout now that both captions and notes are available (#24). That PR should be merged first. 

## Before: 
- Slideshow item displays `item.note` below item title
- Slideshow item displays `experience.summary`

<img width="1190" alt="Screen Shot 2021-10-12 at 7 21 08 AM" src="https://user-images.githubusercontent.com/5402927/136974135-3451da4b-0629-468d-8769-de52d1f34413.png">


## After
- Slideshow item displays `item.caption` below item title
- Slideshow item displays `item.note` 
[screenshot incoming]