### PR TITLE
Update the URL fragment to include the current slide/step, and initialize the experience in the right place on reload

### DIFF
--- a/_wallscreens/silicon-valley/adobe-and-apple/index.html
+++ b/_wallscreens/silicon-valley/adobe-and-apple/index.html
@@ -35,7 +35,7 @@ controller: slideshow
 
       {% for item in experience.items %}
         <link rel="preload" href="{{ item.image }}" as="image">
-        <div data-image-url="{{ item.image }}" data-slideshow-target="slides">
+        <div id="{{ item.title | slugify }}" data-image-url="{{ item.image }}" data-slideshow-target="slides">
 
           <h3 class="item-title">{{ item.title }}</h3>
           <p class="item-caption">{{ item.caption }}</p>

--- a/_wallscreens/silicon-valley/medical-devices/index.html
+++ b/_wallscreens/silicon-valley/medical-devices/index.html
@@ -53,7 +53,7 @@ controller: guided-tour
 
       <div class="bio-card-area">
         {% for item in experience.items %}
-          <div data-guided-tour-target="slides">
+          <div {% if item.bio %}id="{{ item.bio.title | slugify }}"{% endif %} data-guided-tour-target="slides">
             {% if item.bio %}
               <div class="bio-card">
                 <h4>{{ item.bio.title }}</h4>
@@ -74,7 +74,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div class="card d-none" data-guided-tour-target="slides">
+  <div id="last" class="card d-none" data-guided-tour-target="slides">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>

--- a/_wallscreens/silicon-valley/networking/index.html
+++ b/_wallscreens/silicon-valley/networking/index.html
@@ -53,7 +53,7 @@ controller: guided-tour
 
       <div class="bio-card-area">
         {% for item in experience.items %}
-          <div data-guided-tour-target="slides">
+          <div {% if item.bio %}id="{{ item.bio.title | slugify }}"{% endif %} data-guided-tour-target="slides">
             {% if item.bio %}
               <div class="bio-card">
                 <h4>{{ item.bio.title }}</h4>
@@ -74,7 +74,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div class="card d-none" data-guided-tour-target="slides">
+  <div id="last" class="card d-none" data-guided-tour-target="slides">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>

--- a/_wallscreens/silicon-valley/silicon-genesis/index.html
+++ b/_wallscreens/silicon-valley/silicon-genesis/index.html
@@ -41,7 +41,7 @@ controller: oral-history
           <h3>{{theme.name}}</h3>
           <ul class="theme-chapter-list">
             {% for item in theme.items %}
-              <li class="chapter" data-timestamp="{{item.timestamp}}" data-oral-history-target="steps">
+              <li id="{{ item.title | slugify }}" class="chapter" data-timestamp="{{item.timestamp}}" data-oral-history-target="steps">
                 <img src="{{item.thumbnail}}" />
                 <h4 class="item-title">{{ item.title }}</h4>
               </li>
@@ -57,7 +57,7 @@ controller: oral-history
     </nav>
   </div>
 
-  <div class="card d-none" data-oral-history-target="steps">
+  <div id="last" class="card d-none" data-oral-history-target="steps">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
 

--- a/_wallscreens/silicon-valley/video-arcades/index.html
+++ b/_wallscreens/silicon-valley/video-arcades/index.html
@@ -35,7 +35,7 @@ controller: slideshow
 
       {% for item in experience.items %}
         <link rel="preload" href="{{ item.image }}" as="image">
-        <div data-image-url="{{ item.image }}" data-slideshow-target="slides">
+        <div id="{{ item.title | slugify }}" data-image-url="{{ item.image }}" data-slideshow-target="slides">
 
           <h3 class="item-title">{{ item.title }}</h3>
           <p class="item-caption">{{ item.caption }}</p>

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -7,6 +7,10 @@ export default class extends Controller {
   connect() {
     if (window.location.hash && this.slidesTargets.findIndex(x => x.id == window.location.hash.substring(1)) > 0) {
       this.indexValue = this.slidesTargets.findIndex(x => x.id == window.location.hash.substring(1));
+
+      window.viewer.addOnceHandler('open', () => {
+        this.indexValueChanged();
+      });
     }
   }
 
@@ -33,6 +37,7 @@ export default class extends Controller {
 
   indexValueChanged() {
     const item = this.getItem();
+    if (item.id) history.replaceState({}, '', '#' + item.id);
 
     this.slidesTargets.forEach(x => x.classList.add('d-none'));
     item.classList.remove('d-none');

--- a/js/controllers/oral-history.js
+++ b/js/controllers/oral-history.js
@@ -1,10 +1,15 @@
 import { Controller } from "/js/stimulus.js"
 
 export default class extends Controller {
-  static values = { index: { type: Number, default: 0 } }
+  static values = { index: { type: Number, default: 0 }, start: { type: Number, default: 0} }
   static targets = [ "chapterContainer", "steps", "video" ]
 
   connect() {
+    if (window.location.hash && this.stepsTargets.findIndex(x => x.id == window.location.hash.substring(1)) > 0) {
+      this.indexValue = this.stepsTargets.findIndex(x => x.id == window.location.hash.substring(1));
+      this.startValue = this.getItem().dataset?.timestamp;
+    }
+
     this.registerPlayerHooks();
   }
 
@@ -19,6 +24,8 @@ export default class extends Controller {
       const index = timestamps.findIndex((timestamp)=>(Number.isFinite(timestamp.start) && timestamp.start < event.target.currentTime && timestamp.end > event.target.currentTime));
       if (index >= 0 && this.indexValue != index) this.indexValue = index;
     };
+
+    this.videoTarget.addEventListener('loadedmetadata', () => { if (this.startValue > 0) this.videoTarget.currentTime = this.startValue }, false)
   }
 
   // start playing the video from the first chapter
@@ -59,6 +66,7 @@ export default class extends Controller {
   // update the HTML to match the current chapter/step state
   indexValueChanged() {
     const item = this.getItem();
+    if (item.id) history.replaceState({}, '', '#' + item.id);
 
     // hide/dehighlight all the other steps/chapters
     this.stepsTargets.forEach(x => {

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -34,6 +34,7 @@ export default class extends Controller {
   // make the current item visible
   indexValueChanged() {
     const item = this.getItem();
+    if (item.id) history.replaceState({}, '', '#' + item.id);
 
     this.slidesTargets.forEach(x => x.classList.add('d-none'));
     this.slideAreaTarget.style['background-image'] = "url(" + item.dataset.imageUrl + ")";


### PR DESCRIPTION
This is a little developer experience tweak so the browser keeps us in the same state after it refreshes.
