### PR TITLE
Oral history auto-restart (#59)

### DIFF
--- a/_layouts/wallscreen.html
+++ b/_layouts/wallscreen.html
@@ -22,7 +22,7 @@
   </head>
 
   <body>
-    <div class="wallscreen" {% if page.controller %} data-controller="{{ page.controller }} more-info" data-action="more-info:show->oral-history#pause more-info:hide->oral-history#unpause"{% endif %}>
+    <div class="wallscreen" {% if page.controller %} data-controller="{{ page.controller }} more-info" data-action="more-info:show->oral-history#pause more-info:hide->oral-history#unpause more-info:show->oral-history#resetRestartTimer more-info:hide->oral-history#resetRestartTimer"{% endif %}>
       {{ content }}
     </div>
   </body>

--- a/js/controllers/oral-history.js
+++ b/js/controllers/oral-history.js
@@ -38,6 +38,8 @@ export default class extends Controller {
 
   // return to the initial slide with "start" button
   restart() {
+    if (!this.ended) return;
+
     this.indexValue = 0;
   }
 
@@ -49,21 +51,14 @@ export default class extends Controller {
 
   // pause the video
   pause() {
-    if (!this.ended) this.videoTarget.pause();
-
-    // if this is called when the video is already over (i.e. by the modal), 
-    // reset the interaction timer to prevent the experience from restarting
-    // while the modal is still open
-    else this.resetRestartTimer();
+    this.videoTarget.pause();
   }
 
   // resume playing the video
   unpause() {
-    if (!this.ended) this.videoTarget.play();
+    if (this.ended) return;
 
-    // if this is called when the video is already over (i.e. by the modal), 
-    // reset the interaction timer because the user pressed a button
-    else this.resetRestartTimer();
+    this.videoTarget.play();
   }
 
   // when the video finishes playing, advance to the end slide


### PR DESCRIPTION
feedback appreciated since this gets a little tangled. my understanding is:

- when the video finishes playing OR the user clicks "next" enough times, we arrive at the final card/slide (the one with the QR codes)
- at this point, a timer is started that will restart the experience to the first card/slide and play the video (<s>not the intro card but the actual first chapter/clip</s> fixed; it does now go to the intro card)
- if the user opens the modal at this point, it will reset the restart timer _and_ start the modal's own close timer. the modal's timer is shorter, so it's guaranteed to auto-close the modal first before restarting the experience.
- if the user then _closes_ the modal, that interaction will <s>cause the video to resume playing, which will seek it back to the beginning, which will effectively restart the experience immediately. idk if this is intended behavior, but it seems reasonable.</s> fixed; it resets the restart timer but doesn't do anything else.

if the user opens the modal at any other time, e.g. during playback, the modal's own timer will ensure it eventually is closed and playback resumes, so the experience can never be "frozen".