### PR TITLE
Adjust styling of last card.

### DIFF
--- a/_wallscreens/silicon-valley/adobe-and-apple/index.html
+++ b/_wallscreens/silicon-valley/adobe-and-apple/index.html
@@ -57,7 +57,7 @@ controller: slideshow
     </nav>
   </div>
 
-  <div id="last" class="card d-none" data-slideshow-target="slides">
+  <div id="last" class="card last-card d-none" data-slideshow-target="slides">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
 
@@ -70,15 +70,17 @@ controller: slideshow
       {% endfor %}
     </div>
 
-    <h3>Explore other slideshows</h3>
-    <nav class="card-nav">
-      {% for wallscreen_experience in wallscreen.experiences %}
-        {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
-        {% if other_experience.type == experience.type and other_experience.key != page.experience %}
-          <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
-        {% endif %}
-      {% endfor %}
-    </nav>
+    <div class="card-footer">
+      <h3>Explore other slideshows</h3>
+      <nav class="card-nav">
+        {% for wallscreen_experience in wallscreen.experiences %}
+          {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
+          {% if other_experience.type == experience.type and other_experience.key != page.experience %}
+            <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
+          {% endif %}
+        {% endfor %}
+      </nav>
+    </div>
   </div>
 </aside>
 

--- a/_wallscreens/silicon-valley/medical-devices/index.html
+++ b/_wallscreens/silicon-valley/medical-devices/index.html
@@ -77,7 +77,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div id="last" class="card d-none" data-guided-tour-target="slides">
+  <div id="last" class="card last-card d-none" data-guided-tour-target="slides">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
@@ -92,15 +92,17 @@ controller: guided-tour
       {% endfor %}
     </div>
 
-    <h3>Explore other guided tours</h3>
-    <nav class="card-nav">
-      {% for wallscreen_experience in wallscreen.experiences %}
-        {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
-        {% if other_experience.type == experience.type and other_experience.key != page.experience %}
-          <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
-        {% endif %}
-      {% endfor %}
-    </nav>
+    <div class="card-footer">
+      <h3>Explore other guided tours</h3>
+      <nav class="card-nav">
+        {% for wallscreen_experience in wallscreen.experiences %}
+          {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
+          {% if other_experience.type == experience.type and other_experience.key != page.experience %}
+            <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
+          {% endif %}
+        {% endfor %}
+      </nav>
+    </div>
   </div>
 </aside>
 

--- a/_wallscreens/silicon-valley/networking/index.html
+++ b/_wallscreens/silicon-valley/networking/index.html
@@ -77,7 +77,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div id="last" class="card d-none" data-guided-tour-target="slides">
+  <div id="last" class="card last-card d-none" data-guided-tour-target="slides">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
@@ -92,15 +92,17 @@ controller: guided-tour
       {% endfor %}
     </div>
 
-    <h3>Explore other guided tours</h3>
-    <nav class="card-nav">
-      {% for wallscreen_experience in wallscreen.experiences %}
-        {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
-        {% if other_experience.type == experience.type and other_experience.key != page.experience %}
-          <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
-        {% endif %}
-      {% endfor %}
-    </nav>
+    <div class="card-footer">
+      <h3>Explore other guided tours</h3>
+      <nav class="card-nav">
+        {% for wallscreen_experience in wallscreen.experiences %}
+          {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
+          {% if other_experience.type == experience.type and other_experience.key != page.experience %}
+            <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
+          {% endif %}
+        {% endfor %}
+      </nav>
+    </div>
   </div>
 </aside>
 

--- a/_wallscreens/silicon-valley/silicon-genesis/index.html
+++ b/_wallscreens/silicon-valley/silicon-genesis/index.html
@@ -72,7 +72,7 @@ controller: oral-history
     </nav>
   </div>
 
-  <div id="last" class="card d-none" data-oral-history-target="steps">
+  <div id="last" class="card last-card d-none" data-oral-history-target="steps">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
       <p class="experience-subtitle">{{ experience.subtitle }} </p>
@@ -90,15 +90,17 @@ controller: oral-history
         </div>
       {% endfor %}
     </div>
-    <h3>Explore other oral history collections</h3>
-    <nav class="card-nav">
-      {% for wallscreen_experience in wallscreen.experiences %}
-        {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
-        {% if other_experience.type == experience.type and other_experience.key != page.experience %}
-          <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label }}</a>
-        {% endif %}
-      {% endfor %}
-    </nav>
+    <div class="card-footer">
+      <h3>Explore other oral history collections</h3>
+      <nav class="card-nav">
+        {% for wallscreen_experience in wallscreen.experiences %}
+          {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
+          {% if other_experience.type == experience.type and other_experience.key != page.experience %}
+            <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label }}</a>
+          {% endif %}
+        {% endfor %}
+      </nav>
+    </div>
   </div>
 </aside>
 

--- a/_wallscreens/silicon-valley/video-arcades/index.html
+++ b/_wallscreens/silicon-valley/video-arcades/index.html
@@ -57,7 +57,7 @@ controller: slideshow
     </nav>
   </div>
 
-  <div id="last" class="card d-none" data-slideshow-target="slides">
+  <div id="last" class="card last-card d-none" data-slideshow-target="slides">
     <div class="card-content">
       <h2 class="experience-title border-none">{{ experience.title}}</h2>
 
@@ -70,15 +70,17 @@ controller: slideshow
       {% endfor %}
     </div>
 
-    <h3>Explore other slideshows</h3>
-    <nav class="card-nav">
-      {% for wallscreen_experience in wallscreen.experiences %}
-        {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
-        {% if other_experience.type == experience.type and other_experience.key != page.experience %}
-          <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
-        {% endif %}
-      {% endfor %}
-    </nav>
+    <div class="card-footer">
+      <h3>Explore other slideshows</h3>
+      <nav class="card-nav">
+        {% for wallscreen_experience in wallscreen.experiences %}
+          {% assign other_experience = site.data.experiences[wallscreen_experience.key] %}
+          {% if other_experience.type == experience.type and other_experience.key != page.experience %}
+            <a href="{% link _wallscreens/{{ page.wallscreen }}/{{ other_experience.key }}/index.html %}" class="button">{{ other_experience.button_label}}</a>
+          {% endif %}
+        {% endfor %}
+      </nav>
+    </div>
   </div>
 </aside>
 

--- a/css/wallscreens/styles.css
+++ b/css/wallscreens/styles.css
@@ -96,7 +96,7 @@ pre {
   display: flex;
   flex-direction: column;
   grid-area: card;
-  padding: 1rem;
+  padding: 3rem;
 }
 
 .card {
@@ -318,4 +318,48 @@ p.experience-subtitle {
   margin: 0 auto;
   background-color: var(--color-primary-dark);
   color: white;
+}
+
+/* Last Card */
+
+.last-card h3 {
+  margin-top: 30px;
+  text-transform: uppercase;
+}
+
+.last-card .experience-attribution {
+  padding-bottom: 35px;
+  padding-top: 10px;
+}
+
+.last-card .dig-deeper-card {
+  padding-top: 25px;
+}
+
+.card-footer h3 {
+  margin-bottom: 30px;
+  overflow: hidden;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.card-footer h3:before {
+  right: 0.5em;
+  margin-left: -50%;
+}
+
+.card-footer h3:after {
+  left: 0.5em;
+  margin-right: -50%;
+}
+
+.card-footer h3:before,
+.card-footer h3:after {
+  background-color: #ddd;
+  content: "";
+  display: inline-block;
+  height: 1px;
+  position: relative;
+  vertical-align: middle;
+  width: 50%;
 }


### PR DESCRIPTION
I think this PR gets us closer to the mockup style for the last card.

Some caveats and thoughts for future consideration:

- This works on desktop/laptop screen sizes. Likely needs adjustment for wallscreens.
- px vs rem, em, etc. ; unsure of our overall strategy there.
- There is a lot of repeated markup in the index files for each experience; ripe for consolidation at some point.
<img width="697" alt="Screen Shot 2021-10-21 at 2 59 43 PM" src="https://user-images.githubusercontent.com/458247/138340244-e404f07b-d9c5-45c5-bcf2-6a34f4e86823.png">

