### PR TITLE
Reduce width of tour annotation box for readability.

### DIFF
--- a/_scss/wallscreens/experiences/_tour.scss
+++ b/_scss/wallscreens/experiences/_tour.scss
@@ -38,7 +38,7 @@
   position: absolute;
   bottom: 2vw;
   max-height: 20vw;
-  max-width: 80%;
+  max-width: 70ch;
 
   background-color: rgba(255, 255, 255, 0.85);
   box-shadow: 0px 4px 5px rgba(0,0,0,0.25);


### PR DESCRIPTION
The tiniest PR...to reduce the width of the guided tour annotation box. To my eye at this width the annotation box creeps up rather high in cases where the annotation is longer. I've left the width at the proposed `70ch` in case this is an opportunity to suggest shorter annotations.

<img width="432" alt="Screen Shot 2021-10-28 at 9 24 35 AM" src="https://user-images.githubusercontent.com/458247/139264985-1011e680-d512-43f8-bce0-5b95b3492e0b.png">