### PR TITLE
Load guided tour image from local file or IIIF.

### DIFF
--- a/_data/experiences/medical-devices.yaml
+++ b/_data/experiences/medical-devices.yaml
@@ -20,6 +20,7 @@ more_info:
     url: https://americanhistory.si.edu/collections/subjects/health-medicine
 
 image: https://stacks.stanford.edu/image/iiif/xh842zs4872%2Fxh842zs4872_0001/info.json
+local_image: local-media/Content/Image-Derivatives/Guided-Tour-1-Medical-Devices/xh842zs4872_deriv.jpg
 
 viewport:
   zoom: 1

--- a/_data/experiences/networking.yaml
+++ b/_data/experiences/networking.yaml
@@ -21,6 +21,7 @@ more_info:
     url: https://www.youtube.com/watch?v=SZey878-Mp4
 
 image: https://stacks.stanford.edu/image/iiif/gb738dt2052%2Fgb738dt2052_0001/info.json
+local_image: local-media/Content/Image-Derivatives/Guided-Tour-2-Computer-Networking/gb738dt2052_deriv.jpg
 
 viewport:
   zoom: 1

--- a/_wallscreens/silicon-valley/medical-devices/index.html
+++ b/_wallscreens/silicon-valley/medical-devices/index.html
@@ -15,6 +15,13 @@ controller: guided-tour
 <main class="content-area">
   <div id="openseadragon" style="width: 100%; height: 100%"></div>
   <script type="text/javascript">
+    image_url = "{% file_or_link {{experience.local_image}} {{experience.image}} %}";
+    if (image_url.endsWith('.json')) {
+      tile_sources = image_url;
+    } else {
+      tile_sources = `{ "type": "image", "url": "${image_url}" }`;
+    }
+
     window.viewer = OpenSeadragon({
         id: "openseadragon",
         showNavigationControl: false,
@@ -23,7 +30,7 @@ controller: guided-tour
         panVertical: false,
         minZoomLevel: 1,
         maxZoomLevel: 1,
-        tileSources: "{{ experience.image }}"
+        tileSources: tile_sources
     });
 </script>
   <div class="caption d-none" data-guided-tour-target="caption"></div>

--- a/_wallscreens/silicon-valley/networking/index.html
+++ b/_wallscreens/silicon-valley/networking/index.html
@@ -15,6 +15,13 @@ controller: guided-tour
 <main class="content-area">
   <div id="openseadragon" style="width: 100%; height: 100%"></div>
   <script type="text/javascript">
+    image_url = "{% file_or_link {{experience.local_image}} {{experience.image}} %}";
+    if (image_url.endsWith('.json')) {
+      tile_sources = image_url;
+    } else {
+      tile_sources = `{ "type": "image", "url": "${image_url}" }`;
+    }
+
     window.viewer = OpenSeadragon({
         id: "openseadragon",
         showNavigationControl: false,
@@ -23,7 +30,7 @@ controller: guided-tour
         panVertical: false,
         minZoomLevel: 1,
         maxZoomLevel: 1,
-        tileSources: "{{ experience.image }}"
+        tileSources: tile_sources
     });
 </script>
   <div class="caption d-none" data-guided-tour-target="caption"></div>


### PR DESCRIPTION
This uses the custom `file_or_link` liquid tag to use either a locally supplied image if present or fallback to the stacks image info URL to load the image into openseadragon for the guided tours.

I've left the x,y coordinates as is for now. They work fine for the stacks supplied image, but not for the local images at their current size. Will likely need adjustment once we receive the larger derivatives.