### PR TITLE
Set defaultZoomLevel on guided tour to remove border from stacks images.

### DIFF
--- a/_wallscreens/silicon-valley/medical-devices/index.html
+++ b/_wallscreens/silicon-valley/medical-devices/index.html
@@ -30,6 +30,7 @@ controller: guided-tour
         panVertical: false,
         minZoomLevel: 1,
         maxZoomLevel: 1,
+        defaultZoomLevel: 1.08,
         tileSources: tile_sources
     });
 </script>

--- a/_wallscreens/silicon-valley/networking/index.html
+++ b/_wallscreens/silicon-valley/networking/index.html
@@ -30,6 +30,7 @@ controller: guided-tour
         panVertical: false,
         minZoomLevel: 1,
         maxZoomLevel: 1,
+        defaultZoomLevel: 1.08,
         tileSources: tile_sources
     });
 </script>


### PR DESCRIPTION
Closes #110.

This sets the default zoom to remove the border from the stacks supplied images. This may need to be adjusted or removed once we get the larger derivatives for the offline/wallscreens build.