### PR TITLE
Rearrange titles of guided tours to be unique

### DIFF
--- a/_data/experiences/medical-devices.yaml
+++ b/_data/experiences/medical-devices.yaml
@@ -1,8 +1,8 @@
 key: medical-devices
 type: tour
-button_label: Medical Device Inventors
-title: Silicon Valley Inventor Group Portraits
-subtitle: Medical Devices
+button_label: Medical Devices
+title: Medical Devices
+subtitle: Silicon Valley Inventor Group Portraits
 date: 2011
 creator: Terry Guyer
 summary: Harold Hohbach commissioned artist Terry Guyer to create eight museum-quality portraits, by time period and industry, portraying Silicon Valley inventors and pioneers. The goal of the commission was to inspire the next generation of young people to follow in the footsteps of the pioneers portrayed in the portraits.

--- a/_data/experiences/networking.yaml
+++ b/_data/experiences/networking.yaml
@@ -1,8 +1,8 @@
 key: networking
 type: tour
 button_label: Computer Networking
-title: Silicon Valley Inventor Group Portraits
-subtitle: Computer Networking and Internet Connectivity Pioneers of Silicon Valley
+title: Computer Networking and Internet Connectivity
+subtitle: Silicon Valley Inventor Group Portraits
 date: 2018
 creator: Terry Guyer
 summary: The Silicon Valley Luminary Society, founded by Harold Hohbach in 1998, was created to commission a series of group portrait paintings, each portraying the "pioneers of Silicon Valley" in a specific area of technology. The purpose of these paintings was to inspire a new generation to follow in the footsteps of the individuals depicted in the portraits. "Computer Networking and Internet Connectivity Pioneers of Silicon Valley," painted by Terry Guyer, is the seventh painting in the series. This group portrait captures five individuals whose work on network technologies made office connectivity and the Internet possible. Don Nielsen, Vint Cerf, Sandy Lerner, Robert Metcalfe stand together in an idealized scene that also depicts artifacts of network technology, as well as a sign for Rossotti's Alpine Inn in Portola Valley, California, a popular beer garden where the first internet transmission took place.


### PR DESCRIPTION
Closes #122.

Henry okayed the proposal to swap titles/subtitles in the wallscreen #7 guided tours (so that the titles are unique).

### Before
<img width="1271" alt="Screen Shot 2021-11-01 at 4 06 12 PM" src="https://user-images.githubusercontent.com/101482/139755609-a0c87734-92c8-4fcb-b2bc-201411b7e71d.png">


### After
<img width="1272" alt="Screen Shot 2021-11-01 at 4 21 45 PM" src="https://user-images.githubusercontent.com/101482/139755622-87584b98-adcb-4357-b92c-0e3ecced3312.png">

---
<img width="1272" alt="Screen Shot 2021-11-01 at 4 28 04 PM" src="https://user-images.githubusercontent.com/101482/139755643-1b8b1473-f8ae-4c5a-920e-64f70f6e455d.png">

