### PR TITLE
remove padding from attact-mode-grid

### DIFF
--- a/_scss/wallscreens/_global.scss
+++ b/_scss/wallscreens/_global.scss
@@ -17,6 +17,13 @@ html {
     }
 }
 
+// Use more intuitive box-sizing for all elements
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
 // Default line-height for text content
 body {
     line-height: 1.25;

--- a/_scss/wallscreens/attractors/_grid.scss
+++ b/_scss/wallscreens/attractors/_grid.scss
@@ -4,7 +4,6 @@
   grid-template-columns: repeat(3, 1fr);
   width: 100%;
   height: 100%;
-  padding: 1rem;
 
   .attract-image {
     background-size: cover;

--- a/_scss/wallscreens/attractors/_grid.scss
+++ b/_scss/wallscreens/attractors/_grid.scss
@@ -4,6 +4,7 @@
   grid-template-columns: repeat(3, 1fr);
   width: 100%;
   height: 100%;
+  padding: 1rem;
 
   .attract-image {
     background-size: cover;


### PR DESCRIPTION
Grid was pushed over into the card/slide div maybe due to recent css changes.

Before:

<img width="1151" alt="Screen Shot 2021-11-02 at 10 54 55 AM" src="https://user-images.githubusercontent.com/458247/139872263-835e5c9b-8ef8-4232-9238-12ddc58edcf0.png">


After:
<img width="783" alt="Screen Shot 2021-11-02 at 10 58 14 AM" src="https://user-images.githubusercontent.com/458247/139872480-384fe586-24e9-4950-afe6-68ba9f3dd239.png">


