### PR TITLE
qr code styling

### DIFF
--- a/_scss/wallscreens/_links.scss
+++ b/_scss/wallscreens/_links.scss
@@ -4,5 +4,5 @@ a[data-qr] {
 }
 
 .qrcode {
-  margin-left: -6px;
+  height: 3.5rem;
 }

--- a/_scss/wallscreens/_modal.scss
+++ b/_scss/wallscreens/_modal.scss
@@ -94,9 +94,7 @@
   .qrcode {
     position: absolute;
     left: 0;
-    top: 0;
-    height: 4rem;
-    margin-left: -0.5rem;
+    top: .4em;
   }
 
   .close {

--- a/js/application.js
+++ b/js/application.js
@@ -1,6 +1,6 @@
 window.addEventListener('load', function() {
   document.querySelectorAll('[data-qr]').forEach(function(e) {
-    QRCode.toDataURL(e.getAttribute('href'), { color: { light: '#0000' }, width: 60 }, function (err, url) {
+    QRCode.toDataURL(e.getAttribute('href'), { color: { light: '#0000' }, width: 120, margin: 0 }, function (err, url) {
       var img = document.createElement('img');
       img.setAttribute('class', 'qrcode');
       img.src = url;


### PR DESCRIPTION
this PR ensures that QR codes are large enough (hopefully!) to be useful on full wallscreen size, and renders a larger-size image so that they appear less blurry when scaled up. it also removes the margin that was rendered as part of the image so that they are easier to align on the page.
