### PR TITLE
Add experience subtitles to slideshow data and layouts

### DIFF
--- a/_data/experiences/adobe-and-apple.yaml
+++ b/_data/experiences/adobe-and-apple.yaml
@@ -2,6 +2,7 @@ key: adobe-and-apple
 type: slideshow
 button_label: Adobe and Apple
 title: Adobe and Apple
+subtitle: Photographs from the Douglas Menuez Photography Collection
 summary: Douglas Menuez has documented progress in Silicon Valley during a period stretching from the early 1980s through the Internet boom.  With an eye for capturing illustrative moments in the histories of companies such as Adobe, Apple, NeXT, Intel, Sun Microsystems, IBM, and several startups, he has worked behind the scenes in a range of settings from boardrooms to design meetings to launch events.
 more_info:
   - type: Website

--- a/_data/experiences/labor.yaml
+++ b/_data/experiences/labor.yaml
@@ -2,6 +2,7 @@ key: labor
 type: slideshow
 button_label: Labor
 title: Labor
+subtitle: "Work & Social Justice: The David Bacon Photography Archive at Stanford"
 summary: David Bacon (born 1948) is a photojournalist, author, political activist, and union organizer who has focused on labor issues, particularly those related to immigrant labor. He has published several books, essays and articles on subjects including the history of the United Farm Workers; the working and living condition of farm workers in California; the work lives of workers; and many other topics. The images shown here have been selected from the David Bacon photography archive, circa 1985-2019, at Stanford.
 more_info:
   - type: Online Exhibit

--- a/_data/experiences/richard-weiland.yaml
+++ b/_data/experiences/richard-weiland.yaml
@@ -2,6 +2,7 @@ key: richard-weiland
 type: slideshow
 button_label: Richard "Ric" Weiland
 title: Richard "Ric" Weiland
+subtitle: Images from the Richard William Weiland Papers
 summary: Richard Weiland, usually called “Ric,” earned his undergraduate degree in electrical engineering at Stanford in 1976. His first job after Stanford was with his former high school classmates Bill Gates and Paul Allen at Microsoft, where he managed the completion of the COBOL compiler and helped develop Microsoft’s BASIC interpreter. He left the company at the age of 35 in 1988 to pursue full-time philanthropy, where his interests included education; lesbian, gay, bisexual and transgender rights; health and human services; and the environment.  The Weiland papers in the Stanford Libraries document his work at Microsoft, as an activist for the LGBTQ movement (particularly in the Seattle area), and his extensive philanthropy, as well as his personal life.
 more_info:
   - type: Catalog record

--- a/_data/experiences/video-arcades.yaml
+++ b/_data/experiences/video-arcades.yaml
@@ -1,7 +1,8 @@
 key: video-arcades
 type: slideshow
 button_label: Bay Area Video Arcades
-title: "Bay Area Video Arcades: Photographs by Ira Nowinski"
+title: Bay Area Video Arcades
+subtitle: Photographs by Ira Nowinski
 summary: "Ira Nowinski (b. 1942) has enjoyed a wide-ranging and critically recognized career as a documentary photographer. His photographic series, “Bay Area Video Arcades,” documents the places and people of the San Francisco Bay Area’s videogame arcade culture during the early 1980s. His arcade photographs were taken in 1981 and 1982 at several locations around the Bay Area, including the Santa Cruz Boardwalk, the Exploratorium (site of the 1981 Atari Asteroids competition), and other arcades in Oakland and San Francisco.  The Stanford Libraries acquired this collection from Ira Nowinski in August 2012."
 more_info:
   - type: Website

--- a/_includes/_dig_deeper.html
+++ b/_includes/_dig_deeper.html
@@ -1,4 +1,4 @@
-<h3>Dig deeper</h3>
+<h3 class="dig-deeper">Dig deeper</h3>
 
 {% for item in experience.more_info %}
   <div class="dig-deeper-link">

--- a/_includes/_oral_history.html
+++ b/_includes/_oral_history.html
@@ -30,7 +30,7 @@
   <div class="card" data-oral-history-target="chapterContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <p class="experience-subtitle">{{ experience.subtitle }} </p>
+      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
       {% include _experience_attribution.html %}
       {% assign themes = experience.items | group_by:"theme" %}
       {% for theme in themes %}
@@ -57,7 +57,7 @@
   <div id="last" class="card last-card" data-oral-history-target="steps" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <p class="experience-subtitle">{{ experience.subtitle }} </p>
+      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
       {% include _experience_attribution.html %}
       {% include _dig_deeper.html %}
     </div>

--- a/_includes/_oral_history.html
+++ b/_includes/_oral_history.html
@@ -20,7 +20,7 @@
   <div class="card" data-oral-history-target="steps">
     <div class="card-content experience-index">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <p class="experience-subtitle">{{ experience.subtitle }} </p>
+      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
       {% include _experience_attribution.html %}
       <p class="experience-summary">{{ experience.summary}}</p>
     </div>

--- a/_includes/_slideshow.html
+++ b/_includes/_slideshow.html
@@ -20,6 +20,7 @@
   <div class="card" data-slideshow-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
+      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
 
       {% for item in experience.items %}
         <link rel="preload" href="{% file_or_link {{item.local_image}} {{item.image}} %}" as="image">

--- a/_includes/_slideshow.html
+++ b/_includes/_slideshow.html
@@ -54,6 +54,7 @@
   <div id="last" class="card last-card" data-slideshow-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
+      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
 
       {% include _dig_deeper.html %}
     </div>

--- a/_includes/_slideshow.html
+++ b/_includes/_slideshow.html
@@ -11,6 +11,7 @@
   <div class="card" data-slideshow-target="slides">
     <div class="card-content experience-index">
       <h2 class="experience-title">{{ experience.title }}</h2>
+      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
       <p class="experience-summary">{{ experience.summary }}</p>
     </div>
     {% include _nav_first_card.html %}

--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -23,7 +23,6 @@
 
 .experience-subtitle {
   font-size: 1.75rem;
-  line-height: 1.5;
   font-weight: 600;
 }
 

--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -65,8 +65,7 @@
 /* Last Card */
 .last-card {
 
-  // "dig deeper" text
-  h3 {
+  .dig-deeper {
     font-weight: 600;
     font-size: 1.5rem;
     line-height: 1.5;

--- a/_scss/wallscreens/experiences/_slideshow.scss
+++ b/_scss/wallscreens/experiences/_slideshow.scss
@@ -4,7 +4,7 @@
 
 .wallscreen.slideshow {
   .experience-subtitle {
-    padding-top: 0.25em;
+    padding-top: 0.5em;
     padding-bottom: 0.75em;
     border-bottom: 1px solid #ddd;
   }

--- a/_scss/wallscreens/experiences/_slideshow.scss
+++ b/_scss/wallscreens/experiences/_slideshow.scss
@@ -3,8 +3,9 @@
 // -----------------------------------------------------------------------------
 
 .wallscreen.slideshow {
-  .experience-title {
-    padding-bottom: 1em;
+  .experience-subtitle {
+    padding-top: 0.25em;
+    padding-bottom: 0.75em;
     border-bottom: 1px solid #ddd;
   }
   


### PR DESCRIPTION
I noticed these subtitles were missing from a few slideshows. @ggeisler Can you clarify what the desired styling and behavior is for subtitles?
1. Should experience subtitles appear on all cards (home, intermediate, and final?) 
2. What is the desire styling for subtitles in slideshows? 

### Slideshow subtitle styling from Figma 
![Screen Shot 2021-11-04 at 1 08 31 PM](https://user-images.githubusercontent.com/5402927/140412345-9c257fb5-0795-448f-b991-428c093a5936.png)

### Subtitle styling from local dev
![Screen Shot 2021-11-04 at 1 10 05 PM](https://user-images.githubusercontent.com/5402927/140412522-2398ba32-15f6-4457-bac1-b40d1ecbed5e.png)

![Screen Shot 2021-11-04 at 1 08 53 PM](https://user-images.githubusercontent.com/5402927/140412487-0b98e287-90c4-4020-8bf2-954090a6d9ff.png)
![Screen Shot 2021-11-04 at 1 08 48 PM](https://user-images.githubusercontent.com/5402927/140412489-b2f662d9-687b-4f16-8168-a111362a3d00.png)

