### PR TITLE
container sizes

### DIFF
--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -2,7 +2,13 @@
 // Informational panels/cards on the right side of wallscreen experiences
 // -----------------------------------------------------------------------------
 
+/* Card area */
+.card-area {
+  overflow: scroll;
+}
+
 /* Card */
+
 .experience-title, 
 .experience-subtitle,
 .experience-attribution {

--- a/_scss/wallscreens/_modal.scss
+++ b/_scss/wallscreens/_modal.scss
@@ -7,7 +7,7 @@
   top: 0;
   left: 0;
   width: 100vw;
-  min-height: 100vh;
+  height: 100vh;
   background-color: rgba(0, 0, 0, 0.7);
   display: flex;
   align-items: center;
@@ -19,11 +19,11 @@
     padding: 2.75rem 8.75rem;
     background-color: #f4f4f4;
     max-width: 90vw;
-    max-height: 95vw;
+    max-height: 95vh;
+    overflow: scroll;
     color: #2E2D29;
     border-radius: 8px;
     box-sizing: border-box;
-    overflow: scroll;
   }
 
   .title {

--- a/_scss/wallscreens/_modal.scss
+++ b/_scss/wallscreens/_modal.scss
@@ -40,10 +40,6 @@
     border-bottom: 1px solid #ABABA9;
   }
 
-  .content p {
-    display: inline-block;
-  }
-
   h4 {
     font-size: 1.1rem;
     line-height: 2;


### PR DESCRIPTION
this should resolve the problems @camillevilla noted this morning (fixes #164), and prevent content from overflowing more generally. references #98

- Restrict height of modal content
- Fix display of modal columns in Chrome
- Restrict height of card content
