### PR TITLE
Use html5 hidden attribute instead of utility class

### DIFF
--- a/_includes/perspectives/_modal.html
+++ b/_includes/perspectives/_modal.html
@@ -1,4 +1,4 @@
-<div class="more-info-modal d-none" data-more-info-target="modal">
+<div class="more-info-modal" data-more-info-target="modal" hidden>
   <div class="inner">
     <h2 class="title">{{ wallscreen.more_info.title }}</h2>
     <div class="content">

--- a/_includes/silicon-valley/_modal.html
+++ b/_includes/silicon-valley/_modal.html
@@ -1,4 +1,4 @@
-<div class="more-info-modal d-none" data-more-info-target="modal">
+<div class="more-info-modal" data-more-info-target="modal" hidden>
   <div class="inner">
     <h2 class="title">{{ wallscreen.more_info.title }}</h2>
     <div class="content">

--- a/_scss/wallscreens/_utilities.scss
+++ b/_scss/wallscreens/_utilities.scss
@@ -1,3 +1,0 @@
-.d-none {
-  display: none !important;
-}

--- a/_scss/wallscreens/index.scss
+++ b/_scss/wallscreens/index.scss
@@ -2,7 +2,6 @@
 
 @import 'wallscreens/mixins';
 @import 'wallscreens/global';
-@import 'wallscreens/utilities';
 @import 'wallscreens/typography';
 @import 'wallscreens/forms';
 @import 'wallscreens/media';

--- a/_wallscreens/perspectives/labor/index.html
+++ b/_wallscreens/perspectives/labor/index.html
@@ -37,7 +37,7 @@ controller: slideshow
     </template>
   </div>
 
-  <div class="card d-none" data-slideshow-target="slideContainer">
+  <div class="card" data-slideshow-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 
@@ -65,7 +65,7 @@ controller: slideshow
     </nav>
   </div>
 
-  <div id="last" class="card last-card d-none" data-slideshow-target="slides">
+  <div id="last" class="card last-card" data-slideshow-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 

--- a/_wallscreens/perspectives/richard-weiland/index.html
+++ b/_wallscreens/perspectives/richard-weiland/index.html
@@ -37,7 +37,7 @@ controller: slideshow
     </template>
   </div>
 
-  <div class="card d-none" data-slideshow-target="slideContainer">
+  <div class="card" data-slideshow-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 
@@ -65,7 +65,7 @@ controller: slideshow
     </nav>
   </div>
 
-  <div id="last" class="card last-card d-none" data-slideshow-target="slides">
+  <div id="last" class="card last-card" data-slideshow-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 

--- a/_wallscreens/silicon-valley/adobe-and-apple/index.html
+++ b/_wallscreens/silicon-valley/adobe-and-apple/index.html
@@ -37,7 +37,7 @@ controller: slideshow
     </template>
   </div>
 
-  <div class="card d-none" data-slideshow-target="slideContainer">
+  <div class="card" data-slideshow-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 
@@ -65,7 +65,7 @@ controller: slideshow
     </nav>
   </div>
 
-  <div id="last" class="card last-card d-none" data-slideshow-target="slides">
+  <div id="last" class="card last-card" data-slideshow-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 

--- a/_wallscreens/silicon-valley/medical-devices/index.html
+++ b/_wallscreens/silicon-valley/medical-devices/index.html
@@ -34,7 +34,7 @@ controller: guided-tour
         tileSources: tile_sources
     });
 </script>
-  <div class="caption d-none" data-guided-tour-target="caption"></div>
+  <div class="caption" data-guided-tour-target="caption" hidden></div>
 </main>
 
 <aside class="card-area">
@@ -52,7 +52,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div class="card d-none" data-guided-tour-target="slideContainer">
+  <div class="card" data-guided-tour-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title }}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
@@ -85,7 +85,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div id="last" class="card last-card d-none" data-guided-tour-target="slides">
+  <div id="last" class="card last-card" data-guided-tour-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>

--- a/_wallscreens/silicon-valley/networking/index.html
+++ b/_wallscreens/silicon-valley/networking/index.html
@@ -34,7 +34,7 @@ controller: guided-tour
         tileSources: tile_sources
     });
 </script>
-  <div class="caption d-none" data-guided-tour-target="caption"></div>
+  <div class="caption" data-guided-tour-target="caption" hidden></div>
 </main>
 
 <aside class="card-area">
@@ -52,7 +52,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div class="card d-none" data-guided-tour-target="slideContainer">
+  <div class="card" data-guided-tour-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title }}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
@@ -85,7 +85,7 @@ controller: guided-tour
     </nav>
   </div>
 
-  <div id="last" class="card last-card d-none" data-guided-tour-target="slides">
+  <div id="last" class="card last-card" data-guided-tour-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
       <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>

--- a/_wallscreens/silicon-valley/silicon-genesis/index.html
+++ b/_wallscreens/silicon-valley/silicon-genesis/index.html
@@ -14,7 +14,7 @@ controller: oral-history
 </header>
 
 <main class="content-area">
-  <div class="d-none" data-oral-history-target="videoContainer">
+  <div data-oral-history-target="videoContainer" hidden>
     <video data-oral-history-target="video" muted="true">
       <source src="{% file_or_link {{experience.local_file}} {{experience.file}} %}" type="video/mp4">
     </video>
@@ -46,7 +46,7 @@ controller: oral-history
     </nav>
   </div>
 
-  <div class="card d-none" data-oral-history-target="chapterContainer">
+  <div class="card" data-oral-history-target="chapterContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
       <p class="experience-subtitle">{{ experience.subtitle }} </p>
@@ -59,7 +59,7 @@ controller: oral-history
       </div>
       {% assign themes = experience.items | group_by:"theme" %}
       {% for theme in themes %}
-        <div class="theme d-none" data-oral-history-target="chapterContainer">
+        <div class="theme" data-oral-history-target="chapterContainer" hidden>
           <h3 class="theme-name">{{ theme.name }}</h3>
           <ul class="theme-chapter-list">
             {% for item in theme.items %}
@@ -79,7 +79,7 @@ controller: oral-history
     </nav>
   </div>
 
-  <div id="last" class="card last-card d-none" data-oral-history-target="steps">
+  <div id="last" class="card last-card" data-oral-history-target="steps" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
       <p class="experience-subtitle">{{ experience.subtitle }} </p>

--- a/_wallscreens/silicon-valley/video-arcades/index.html
+++ b/_wallscreens/silicon-valley/video-arcades/index.html
@@ -37,7 +37,7 @@ controller: slideshow
     </template>
   </div>
 
-  <div class="card d-none" data-slideshow-target="slideContainer">
+  <div class="card" data-slideshow-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 
@@ -65,7 +65,7 @@ controller: slideshow
     </nav>
   </div>
 
-  <div id="last" class="card last-card d-none" data-slideshow-target="slides">
+  <div id="last" class="card last-card" data-slideshow-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
 

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -82,14 +82,14 @@ export default class extends Controller {
     const item = this.getItem();
     if (item.id) history.replaceState({}, '', '#' + item.id);
 
-    this.slidesTargets.forEach(x => x.classList.add('d-none'));
-    item.classList.remove('d-none');
+    this.slidesTargets.forEach(x => x.hidden = true);
+    item.hidden = false;
 
     this.slideContainerTargets.forEach(container => {
       if (container.contains(item)) {
-        container.classList.remove('d-none');
+        container.hidden = false;
       } else {
-        container.classList.add('d-none');
+        container.hidden = true;
       }
     });
 
@@ -104,9 +104,9 @@ export default class extends Controller {
 
     if (data.caption) {
       this.captionTarget.innerHTML = data.caption;
-      this.captionTarget.classList.remove('d-none');
+      this.captionTarget.hidden = false;
     } else {
-      this.captionTarget.classList.add('d-none');
+      this.captionTarget.hidden = true;
     }
   }
 }

--- a/js/controllers/more-info.js
+++ b/js/controllers/more-info.js
@@ -14,14 +14,14 @@ export default class extends Controller {
   show() {
     this.dispatch("show");
     gtag('event', 'more-info:show');
-    this.modalTarget.classList.remove('d-none');
+    this.modalTarget.hidden = false;
     this.autohideCallback = window.setTimeout(() => this.hide(), this.constructor.timeout);
   }
 
   hide() {
     this.dispatch("hide");
     gtag('event', 'more-info:hide');
-    this.modalTarget.classList.add('d-none');
+    this.modalTarget.hidden = true;
     if (this.autohideCallback) window.clearTimeout(this.autohideCallback);
   }
 }

--- a/js/controllers/oral-history.js
+++ b/js/controllers/oral-history.js
@@ -116,13 +116,13 @@ export default class extends Controller {
   }
 
   showVideoContainer() {
-    this.videoContainerTarget.classList.remove('d-none');
-    this.attractGridContainerTarget.classList.add('d-none');
+    this.videoContainerTarget.hidden = false;
+    this.attractGridContainerTarget.hidden = true;
   }
 
   showAttractGridContainer() {
-    this.attractGridContainerTarget.classList.remove('d-none');
-    this.videoContainerTarget.classList.add('d-none');
+    this.attractGridContainerTarget.hidden = false;
+    this.videoContainerTarget.hidden = true;
   }
 
   // get the current chapter / step
@@ -156,7 +156,7 @@ export default class extends Controller {
       if (x.classList.contains('chapter'))  {
         x.classList.remove('current')
       } else {
-        x.classList.add('d-none');
+        x.hidden = true;
       }
     })
 
@@ -164,15 +164,15 @@ export default class extends Controller {
     if (item.classList.contains('chapter')){
       item.classList.add('current')
     } else {
-      item.classList.remove('d-none');
+      item.hidden = false;
     }
 
     // reveal the containers (e.g. themes) in this item's hierarchy
     this.chapterContainerTargets.forEach(container => {
       if (container.contains(item)) {
-        container.classList.remove('d-none');
+        container.hidden = false;
       } else {
-        container.classList.add('d-none');
+        container.hidden = true;
       }
     });
   }

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -77,7 +77,7 @@ export default class extends Controller {
     const item = this.getItem();
     if (item.id) history.replaceState({}, '', '#' + item.id);
 
-    this.slidesTargets.forEach(x => x.classList.add('d-none'));
+    this.slidesTargets.forEach(x => x.hidden = true);
     this.slideAreaTarget.innerHTML = "";
     if (item.querySelector('template')) this.slideAreaTarget.appendChild(item.querySelector('template').content.cloneNode(true));
 
@@ -87,13 +87,13 @@ export default class extends Controller {
       this.slideAreaTarget.style['background-image'] = null;
     }
 
-    item.classList.remove('d-none');
+    item.hidden = false;
 
     this.slideContainerTargets.forEach(container => {
       if (container.contains(item)) {
-        container.classList.remove('d-none');
+        container.hidden = false;
       } else {
-        container.classList.add('d-none');
+        container.hidden = true;
       }
     });
   }


### PR DESCRIPTION
this PR isn't strictly necessary, but is related to #87 (and could maybe close it). since we only have one remaining utility class, for showing and hiding things, i decided to take the bootstrap approach and just use the html5 "hidden" attribute instead. the styles we included from reboot mean that this works without needing any more CSS, so we can scrap the utility class.

feel free to treat this as a place for discussion rather than just merging, and I'm open to not doing it – just figured why not since it was more or less a simple find-and-replace, and then we could potentially lay #87 to rest. 

would appreciate someone thoroughly poking the netlify preview too; i tested this locally and it _seemed_ not to change anything but it's tough to be sure.