### PR TITLE
Last cards: Add some QR code spacing; vertically center card content

### DIFF
--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -9,7 +9,7 @@
 
 /* Card */
 
-.experience-title, 
+.experience-title,
 .experience-subtitle,
 .experience-attribution {
   text-align: center;
@@ -65,7 +65,7 @@
 
 /* Last Card */
 .last-card {
-  
+
   // "dig deeper" text
   h3 {
     font-weight: 600;
@@ -82,6 +82,7 @@
 
 .dig-deeper-link {
   margin-top: 1.5em;
+  margin-bottom: 3rem;
   display: flex;
   gap: 1rem;
   font-size: 1.25rem;

--- a/_scss/wallscreens/experiences/_slideshow.scss
+++ b/_scss/wallscreens/experiences/_slideshow.scss
@@ -58,4 +58,11 @@
     margin-top: 1.5em;
     line-height: 1.5;
   }
+
+  .last-card .card-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
This PR: 
1. Adds some spacing between QR codes on last cards ("Dig Deeper" links) - (might close #4)
2. vertically centers last card content to match home card styling. 
  - This puts the QR codes a little lower on the screen (see notes in #4)
  - This matches the mockups a little better, but I'm not sure if moving the "Explore other" options higher is good. 

## Before
![Screen Shot 2021-11-04 at 4 28 40 PM](https://user-images.githubusercontent.com/5402927/140434045-4a603cec-246f-4496-9645-c2debb8c5e3d.png)

## After
![Screen Shot 2021-11-04 at 4 28 21 PM](https://user-images.githubusercontent.com/5402927/140434050-e956459f-d13e-4cd6-aa1a-555619936e26.png)