### PR TITLE
Update styling of "Begin [experience]" button and add animation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,15 @@ defaults:
     values:
       layout: "wallscreen"
       meta: false
+
+experience_types:
+  tour:
+    items_label: "stops"
+  slideshow:
+    items_label: "images"
+  video:
+    items_label: "clips"
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_data/experiences/silicon-genesis.yaml
+++ b/_data/experiences/silicon-genesis.yaml
@@ -4,6 +4,7 @@ subtitle: "Excerpts from <i>Silicon Genesis : An Oral History of Semiconductor T
 date: 1995 - 2018
 creator: Henry Lowood & Rob Walker
 extent: 103 interviews
+duration: 12 minutes
 type: video
 file: https://stanford.box.com/shared/static/e58t96yp5dvhhbhtwsowqtecc6vso8zi.mp4
 local_file: local-media/20210922_2700x1800_Silicon-Genesis_25mbps_final_v1.1_wallscreen.mp4

--- a/_includes/_guided_tour.html
+++ b/_includes/_guided_tour.html
@@ -37,10 +37,7 @@
 
       <p class="experience-summary">{{ experience.summary }}</p>
     </div>
-
-    <nav class="card-nav" data-guided-tour-target="nav">
-      <button class="button" data-action="guided-tour#next"><span>Begin guided tour</span> <i class="fa-solid fas fa-arrow-circle-right"></i></button>
-    </nav>
+    {% include _nav_first_card.html %}
   </div>
 
   <div class="card" data-guided-tour-target="slideContainer" hidden>

--- a/_includes/_nav_first_card.html
+++ b/_includes/_nav_first_card.html
@@ -1,0 +1,19 @@
+<nav class="card-nav" data-{{ page.controller }}-target="nav">
+    <div class="start-button-container">
+      <button class="tall button start-button" data-action="{{ page.controller }}#next">
+        <div class="button-content">
+          <div class="button-labels">
+            <span class="begin-experience">Touch to begin</span>
+            {% if experience.duration %}
+            <span class="experience-duration">{{ experience.duration }}</span>
+            {% else %}
+            <span class="experience-duration">{{ experience.items|size }} {{ site.experience_types[experience.type].items_label }}</span>
+            {% endif %}
+          </div>
+          <div class="button-icon">
+            <i class="fa-solid fas fa-hand-pointer"></i>
+          </div>
+        </div>
+      </button>
+    </div>
+  </nav>

--- a/_includes/_oral_history.html
+++ b/_includes/_oral_history.html
@@ -24,10 +24,7 @@
       {% include _experience_attribution.html %}
       <p class="experience-summary">{{ experience.summary}}</p>
     </div>
-
-    <nav class="card-nav" data-oral-history-target="nav">
-      <button class="button" data-action="oral-history#start"><span>Begin video</span> <i class="fa-solid fas fa-arrow-circle-right"></i></button>
-    </nav>
+    {% include _nav_first_card.html %}
   </div>
 
   <div class="card" data-oral-history-target="chapterContainer" hidden>

--- a/_includes/_slideshow.html
+++ b/_includes/_slideshow.html
@@ -13,11 +13,7 @@
       <h2 class="experience-title">{{ experience.title }}</h2>
       <p class="experience-summary">{{ experience.summary }}</p>
     </div>
-
-    <nav class="card-nav" data-slideshow-target="nav">
-      <button class="button" data-action="slideshow#next"><span>Begin slideshow</span> <i class="fa-solid fas fa-arrow-circle-right"></i></button>
-    </nav>
-
+    {% include _nav_first_card.html %}
     {% include _attract_grid.html %}
   </div>
 

--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -56,3 +56,64 @@ button, .button {
     color: $su-color-stone-dark;
   }
 }
+
+.start-button-container {
+  animation: slowPulse 10s infinite;
+  animation-delay: 5s;
+  border-radius: 1rem;
+}
+
+.button.start-button {
+  border-radius: 1rem;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5);
+  padding: 0.75em 1.75em 0.5em 2.25em;
+
+  .button-content {
+    display: flex;
+  }
+
+  .button-icon {
+    flex-direction: row;
+    display: flex;
+
+    .fa-hand-pointer {
+      align-self: center;
+      color: $su-color-black-60;
+      font-size: 2.25rem;
+      margin-left: 1em;
+    }
+  }
+
+  .button-labels {
+    flex-direction: column;
+    display: flex;
+
+    .begin-experience {
+      color: $su-color-cardinal-red-dark;
+      font-size: 1.25rem;
+      font-weight: bold;
+      padding-bottom: 0.25em;
+      text-shadow: 0 3px 0 rgba(255, 255, 255, 0.4);
+      text-transform: uppercase;
+    }
+
+    .experience-duration {
+      font-size: 1rem;
+      font-style: italic;
+    }
+  }
+}
+
+@keyframes slowPulse {
+	0% {
+		box-shadow: 0 0 0 0 rgba(130, 0, 0, 0.5);
+	}
+
+	70% {
+		box-shadow: 0 0 0 30px rgba(130, 0, 0, 0);
+	}
+
+	100% {
+		box-shadow: 0 0 0 0 rgba(130, 0, 0, 0);
+	}
+}


### PR DESCRIPTION
Closes #125. I'll mark this as a draft so a developer can take over and likely improve/refactor the code. Here's a visual of how things should look:

<img width="437" alt="Screen Shot 2021-11-05 at 12 03 17 PM" src="https://user-images.githubusercontent.com/101482/140565077-4d06cd57-5e95-44f9-8461-db308fce7151.png">

---

Notes:

- For demo purposes I added the PR-related HTML to one experience of each type, but obviously this applies to all experience instances. If not already in the plan, this chunk of code seems ideal for turning into an include (though we'd probably need to add a new data key for the "21 images" duration part, since that's custom to the instance).

- The terminology I'm using for the "duration" part is "N images", "N stops", and "N minutes" (where we round to a whole minutes number for the video duration).

- I might look at replacing the icon with a better non-FontAwesome icon later, but that doesn't seem critical now.





