### PR TITLE
Update size of attractor grid

### DIFF
--- a/_scss/wallscreens/attractors/_grid.scss
+++ b/_scss/wallscreens/attractors/_grid.scss
@@ -1,10 +1,10 @@
 .attract-mode-grid {
   display: grid;
-  grid-gap: 13px;
+  grid-gap: 18px;
   grid-template-columns: repeat(3, 1fr);
   width: 100%;
   height: 100%;
-  padding: 1rem;
+  padding: 6rem;
 
   .attract-image {
     background-size: cover;


### PR DESCRIPTION
This is a minor PR to update the size of the attractor grid (and increase a bit the size of the grid-gap). This will make the grid easier for the visitor to see at a glance and makes it feel like more of a preview than when it fills the content area. (And make it more consistent with the sizing I suggested for the tour attractor in #112).

### Before
<img width="1280" alt="Screen Shot 2021-11-05 at 1 58 10 PM" src="https://user-images.githubusercontent.com/101482/140578938-1c05b91a-b9b6-44f3-8f6d-c1aa31983306.png">

### After
<img width="1280" alt="Screen Shot 2021-11-05 at 2 05 31 PM" src="https://user-images.githubusercontent.com/101482/140578972-6d7ac1e1-8870-4bb2-b45f-2b0fa2da2862.png">

---
<img width="1280" alt="Screen Shot 2021-11-05 at 2 06 37 PM" src="https://user-images.githubusercontent.com/101482/140578993-b10d0212-9b1f-441c-b3bf-25547dd4dbd1.png">


