### PR TITLE
Update styling of card area interview clips

### DIFF
--- a/_data/experiences/silicon-genesis.yaml
+++ b/_data/experiences/silicon-genesis.yaml
@@ -38,16 +38,16 @@ items:
     timestamp: 0
     class: hidden-theme-title
   - key: don-valentine
-    title: From Interview with Don Valentine, April 21, 2004.
+    title: From Interview with Don Valentine, April 21, 2004
     theme: What drew you to Silicon Valley?
     thumbnail: https://via.placeholder.com/100x55
     timestamp: 5
   - key: jerry-sanders
-    title: From Interview with Jerry Sanders, October 18, 2002.
+    title: From Interview with Jerry Sanders, October 18, 2002
     theme: What drew you to Silicon Valley?
     timestamp: 129
   - key: geri-hadley
-    title: From Interview with Geri Hadley, October 22, 2019.
+    title: From Interview with Geri Hadley, October 22, 2019
     theme: What drew you to Silicon Valley?
     timestamp: 194
   - key: title-2

--- a/_scss/wallscreens/experiences/_video.scss
+++ b/_scss/wallscreens/experiences/_video.scss
@@ -17,52 +17,52 @@
     margin: 0 36px;
     text-align: center;
   }
-  
+
   .theme-name {
     font-size: 1.5rem;
     font-weight: 600;
     margin: 1em 0 .75em;
   }
-  
+
   .theme-chapter-list {
     list-style: none;
     padding: 0;
     margin: 0;
   }
-  
+
   .chapter {
     display: flex;
     gap: 25px;
     padding: .75em .6em;
     border-radius: 3px;
-    transition: background-color 0.5s ease;
+    transition: background-color 1s ease;
     font-size: 1.25rem;
   }
-  
+
   .chapter.current {
-    background-color: var(--color-secondary);
+    background-color: $su-color-stone-light;
   }
-  
+
   .chapter-thumbnail {
     flex: none;
-    width: 100px;
-    height: 100px;
+    width: 80px;
+    height: 80px;
     border: 1px solid #979694;
     filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
   }
-  
+
   .chapter-title {
     font-size: 1.25rem;
-    line-height: 1.5;
+    line-height: 1.3;
     flex: auto;
     margin: 0;
     font-weight: normal;
   }
-  
+
   .hidden-theme-title {
     display: none;
   }
-  
+
   p.experience-subtitle {
     font-size: 1.25rem;
     font-weight: 400;


### PR DESCRIPTION
Minor updates to the styling of the oral history card where we show the interviewees. Main things updated:

- Reduce thumbnail size a bit (to ensure the card isn't too packed after we increase size of subtitle)
- Change highlighting color of current interviewee clip (so users don't think it's a button, which use the current background color)
- Remove periods from end of interviewee info (curator-provided, but doesn't seem necessary/adds to visual clutter in display text)

### Before
<img width="439" alt="Screen Shot 2021-11-05 at 4 48 31 PM" src="https://user-images.githubusercontent.com/101482/140590186-477e29f8-344b-421f-86cd-e5d3e2d0a478.png">

### After
<img width="439" alt="Screen Shot 2021-11-05 at 4 47 51 PM" src="https://user-images.githubusercontent.com/101482/140590196-e722ca00-e2bc-402b-9e37-01e616c6a018.png">


