### PR TITLE
Keep scrollbars on card content until curatorial review

### DIFF
--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -4,7 +4,7 @@
 
 /* Card area */
 .card-area {
-  overflow: hidden;
+  overflow: scroll;
 }
 
 /* Card */


### PR DESCRIPTION
Adding this back because it makes the next button inaccessible on some slides

Sample card:
`/wallscreens/silicon-valley/video-arcades/index.html#santa-cruz`