### PR TITLE
analytics environments

### DIFF
--- a/_includes/_analytics.html
+++ b/_includes/_analytics.html
@@ -4,6 +4,12 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
+  
+  gtag('config', 'G-0VWS29BZ43', {
+    'custom_map': {
+      'dimension1': 'environment'
+    }
+  });
 
-  gtag('config', 'G-0VWS29BZ43');
+  gtag('set', 'dimension1', '{{ jekyll.environment }}');
 </script>

--- a/_includes/_analytics.html
+++ b/_includes/_analytics.html
@@ -4,12 +4,6 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  
-  gtag('config', 'G-0VWS29BZ43', {
-    'custom_map': {
-      'dimension1': 'environment'
-    }
-  });
-
-  gtag('set', 'dimension1', '{{ jekyll.environment }}');
+  gtag('set', {'custom_map': {'dimension1': 'environment'}});
+  gtag('config', 'G-0VWS29BZ43', {'environment': '{{ jekyll.environment }}'});
 </script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,7 +12,9 @@
     <link rel="icon" href="{% link images/favicon.ico %}">
 
     <link rel="stylesheet" href="{% link css/index.scss %}">
-    {% include _analytics.html %}
+    {% if jekyll.environment != "development" %}
+      {% include _analytics.html %}
+    {% endif %}
   </head>
   <body>
     <div id="topnav">

--- a/_layouts/wallscreen.html
+++ b/_layouts/wallscreen.html
@@ -20,7 +20,9 @@
     {% if page.extra_css %}
       <link rel="stylesheet" href="{% link css/{{ page.extra_css }}.scss %}">
     {% endif %}
-    {% include _analytics.html %}
+    {% if jekyll.environment != "development" %}
+      {% include _analytics.html %}
+    {% endif %}
   </head>
 
   <body>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+    JEKYLL_ENV = "netlify"


### PR DESCRIPTION
see #121
mutually exclusive with #189; a different approach to the same problem

Goals:

- Don't activate analytics in local dev
- Send environment data to google analytics

<s>draft because still trying to figure out how to correctly send the info to GA & have it show up there</s>

was able to confirm this works using [the approach from this 2020 article](https://medium.com/@postman31/passing-custom-dimensions-with-gtag-js-9317fe45669f), which is a strange hybrid of methods from google's own docs. request payload looks like this; note the `environment` param with every event call:

![Screen Shot 2021-11-09 at 3 18 51 PM](https://user-images.githubusercontent.com/4924494/141021153-0d25ed96-5b7f-4618-acd5-c3f5d96e94c9.png)

the impact of this will be that we'll start getting events in analytics that are tagged with the environment `netlify`, and we won't get any more events from local dev. old events from local dev will show `(not set)` for their environment.

if we want to track events from the physical wallscreens separately, we can do `JEKYLL_ENV=production jekyll build` to create a build that will tag its events as `production`. alternatively, we can even set `JEKYLL_ENV` to `wallscreen11` or something like that and create builds with separate `environment` values per physical wallscreen.

<s>i haven't figured out a great way to surface data on the custom dimension yet, and it looks like it might take 24-48hrs to even be effective in GA anyway...more investigating to do.</s>

here's one way to view the data in GA, on the Life Cycle -> Engagement -> Events page:

https://user-images.githubusercontent.com/4924494/141160350-15f4b2fd-d899-4231-a87b-126773762869.mov



