### PR TITLE
Updates units used for chapter thumbnail sizing

### DIFF
--- a/_scss/wallscreens/experiences/_video.scss
+++ b/_scss/wallscreens/experiences/_video.scss
@@ -45,10 +45,10 @@
 
   .chapter-thumbnail {
     flex: none;
-    width: 80px;
-    height: 80px;
+    width: 3.75em;
+    height: 3.75em;
     border: 1px solid #979694;
-    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
+    filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));
   }
 
   .chapter-title {


### PR DESCRIPTION
In Camille's latest physical screen photos I noticed that the oral history interviewee thumbnails were much too small, which made me realize we're using `px` to size them so of course they aren't scaled up appropriately for the wallscreen.

This PR just changes the units to `em` from `px`, which doesn't change how things look in device-mode and I think should do what we want on the physical screen? We can verify on Camille's next visit.

(I also made the thumbs slightly smaller, and reduced the drop shadow.)

### After
<img width="423" alt="Screen Shot 2021-11-09 at 11 32 20 AM" src="https://user-images.githubusercontent.com/101482/140984139-4badfa18-5a80-4a51-9552-7f15ee2cf02a.png">

