### PR TITLE
hr/border refactor

### DIFF
--- a/_includes/_guided_tour.html
+++ b/_includes/_guided_tour.html
@@ -34,7 +34,7 @@
       <h2 class="experience-title">{{ experience.title}}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
-
+      <hr/>
       <p class="experience-summary">{{ experience.summary }}</p>
     </div>
     {% include _nav_first_card.html %}
@@ -45,9 +45,9 @@
       <h2 class="experience-title">{{ experience.title }}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
-
+      <hr/>
       <p class="experience-summary">{{ experience.short_summary }}</p>
-
+      <hr class="small"/>
       <div class="bio-card-area">
         {% for item in experience.items %}
           <div {% if item.bio %}id="{{ item.key }}"{% endif %} data-guided-tour-target="slides">
@@ -79,6 +79,7 @@
       <h2 class="experience-title">{{ experience.title}}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
+      <hr/>
       {% include _dig_deeper.html %}
     </div>
     {% include _nav_last_card.html %}

--- a/_includes/_guided_tour.html
+++ b/_includes/_guided_tour.html
@@ -32,7 +32,7 @@
   <div class="card" data-guided-tour-target="slides">
     <div class="card-content experience-index">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
 
       <p class="experience-summary">{{ experience.summary }}</p>
@@ -43,7 +43,7 @@
   <div class="card" data-guided-tour-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title }}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
 
       <p class="experience-summary">{{ experience.short_summary }}</p>
@@ -77,7 +77,7 @@
   <div id="last" class="card last-card" data-guided-tour-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
       {% include _dig_deeper.html %}
     </div>

--- a/_includes/_modal.html
+++ b/_includes/_modal.html
@@ -4,6 +4,7 @@
     <div class="content">
       {{ wallscreen.more_info.content }}
     </div>
+    <hr/>
     <h4>For more information</h4>
     <ul class="links">
     {% for link in wallscreen.more_info.links %}

--- a/_includes/_oral_history.html
+++ b/_includes/_oral_history.html
@@ -22,6 +22,8 @@
       <h2 class="experience-title">{{ experience.title}}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
+      <hr/>
+
       <p class="experience-summary">{{ experience.summary}}</p>
     </div>
     {% include _nav_first_card.html %}
@@ -32,6 +34,7 @@
       <h2 class="experience-title">{{ experience.title}}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
+      <hr/>
       {% assign themes = experience.items | group_by:"theme" %}
       {% for theme in themes %}
         <div class="theme" data-oral-history-target="chapterContainer" hidden>
@@ -59,6 +62,7 @@
       <h2 class="experience-title">{{ experience.title}}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
+      <hr/>
       {% include _dig_deeper.html %}
     </div>
     {% include _nav_last_card.html %}

--- a/_includes/_oral_history.html
+++ b/_includes/_oral_history.html
@@ -20,7 +20,7 @@
   <div class="card" data-oral-history-target="steps">
     <div class="card-content experience-index">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
       <p class="experience-summary">{{ experience.summary}}</p>
     </div>
@@ -30,7 +30,7 @@
   <div class="card" data-oral-history-target="chapterContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
       {% assign themes = experience.items | group_by:"theme" %}
       {% for theme in themes %}
@@ -57,7 +57,7 @@
   <div id="last" class="card last-card" data-oral-history-target="steps" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
       {% include _experience_attribution.html %}
       {% include _dig_deeper.html %}
     </div>

--- a/_includes/_slideshow.html
+++ b/_includes/_slideshow.html
@@ -12,7 +12,7 @@
     <div class="card-content experience-index">
       <h2 class="experience-title">{{ experience.title }}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
-      
+      <hr/>
       <p class="experience-summary">{{ experience.summary }}</p>
     </div>
     {% include _nav_first_card.html %}
@@ -23,7 +23,7 @@
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
-
+      <hr/>
       {% for item in experience.items %}
         <link rel="preload" href="{% file_or_link {{item.local_image}} {{item.image}} %}" as="image">
         <div id="{{ item.title | slugify }}" data-image-url="{% file_or_link {{item.local_image}} {{item.image}} %}" data-slideshow-target="slides">
@@ -36,6 +36,7 @@
             <span class="item-creator">{{ item.creator }}</span>
           </div>
           <div class="item-collection">{{ item.collection }}</div>
+          <hr class="small"/>
 
           <p class="item-note">{{ item.note }}</p>
 
@@ -56,7 +57,7 @@
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
       {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
-
+      <hr/>
       {% include _dig_deeper.html %}
     </div>
 

--- a/_includes/_slideshow.html
+++ b/_includes/_slideshow.html
@@ -11,7 +11,8 @@
   <div class="card" data-slideshow-target="slides">
     <div class="card-content experience-index">
       <h2 class="experience-title">{{ experience.title }}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
+      
       <p class="experience-summary">{{ experience.summary }}</p>
     </div>
     {% include _nav_first_card.html %}
@@ -21,7 +22,7 @@
   <div class="card" data-slideshow-target="slideContainer" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
 
       {% for item in experience.items %}
         <link rel="preload" href="{% file_or_link {{item.local_image}} {{item.image}} %}" as="image">
@@ -54,7 +55,7 @@
   <div id="last" class="card last-card" data-slideshow-target="slides" hidden>
     <div class="card-content">
       <h2 class="experience-title">{{ experience.title}}</h2>
-      <h3 class="experience-subtitle">{{ experience.subtitle }}</h3>
+      {% if experience.subtitle %}<h3 class="experience-subtitle">{{ experience.subtitle }}</h3>{% endif %}
 
       {% include _dig_deeper.html %}
     </div>

--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -8,6 +8,9 @@
 }
 
 /* Card */
+.card-content hr {
+  flex: none;
+}
 
 .experience-title,
 .experience-subtitle,
@@ -24,18 +27,17 @@
 .experience-subtitle {
   font-size: 1.75rem;
   font-weight: 600;
+  margin-top: 0.2em;
 }
 
 .experience-summary {
   font-size: 1.25rem;
   line-height: 1.5;
-  margin-top: 1.5em;
 }
 
 .experience-attribution {
   font-size: 1.25rem;
-  padding-bottom: 1em;
-  border-bottom: 1px solid #ddd;
+  margin-top: 0.5em;
 }
 
 .separator {
@@ -64,12 +66,10 @@
 
 /* Last Card */
 .last-card {
-
   .dig-deeper {
     font-weight: 600;
     font-size: 1.5rem;
     line-height: 1.5;
-    margin-top: 1.75em;
     text-transform: uppercase;
   }
 

--- a/_scss/wallscreens/_modal.scss
+++ b/_scss/wallscreens/_modal.scss
@@ -36,8 +36,6 @@
     columns: 2;
     column-gap: 140px;
     margin-top: 0.9em;
-    padding-bottom: 1.5em;
-    border-bottom: 1px solid #ABABA9;
   }
 
   h4 {
@@ -45,7 +43,6 @@
     line-height: 2;
     text-transform: uppercase;
     font-weight: 600;
-    margin-top: 0.6em;
   }
 
   .links {

--- a/_scss/wallscreens/_typography.scss
+++ b/_scss/wallscreens/_typography.scss
@@ -14,3 +14,17 @@ i, em {
 b, strong {
     font-weight: bold;
 }
+
+// Horizontal rules
+hr {
+    width: 100%;
+    height: 1px;
+    background-color: $su-color-black-20;
+    border: none;
+    margin: 2rem auto;
+
+    // Half-width version
+    &.small {
+        width: 50%;
+    }
+}

--- a/_scss/wallscreens/experiences/_slideshow.scss
+++ b/_scss/wallscreens/experiences/_slideshow.scss
@@ -3,18 +3,10 @@
 // -----------------------------------------------------------------------------
 
 .wallscreen.slideshow {
-  .experience-subtitle {
-    padding-top: 0.5em;
-    padding-bottom: 0.75em;
-    border-bottom: 1px solid #ddd;
-  }
-  
   .item-title {
     font-size: 1.5rem;
-    line-height: 1.5;
     color: $su-color-archway-dark;
     font-weight: 600;
-    margin-top: 1.25em;
   }
   
   .item-attribution,
@@ -22,6 +14,7 @@
   .item-note,
   .item-caption {
     font-size: 1.25rem;
+    line-height: 1.5;
   }
   
   .item-collection {
@@ -33,30 +26,11 @@
   
   .item-caption {
     font-style: italic;
-    margin-top: 0.3em;
     line-height: 1.5;
-  }
-
-  .item-attribution {
-    margin-top: 2em;
-  }
-
-  .item-collection {
-    margin-top: 0.3em;
-  }
-
-  // half-width horizontal rule/border
-  .item-collection::after {
-    display: block;
-    margin: 2em auto 0;
-    width: 50%;
-    height: 100%;
-    content: "";
-    border-bottom: 1px solid #ddd;
+    margin-bottom: 1em;
   }
 
   .item-note {
-    margin-top: 1.5em;
     line-height: 1.5;
   }
 

--- a/_scss/wallscreens/experiences/_tour.scss
+++ b/_scss/wallscreens/experiences/_tour.scss
@@ -3,14 +3,6 @@
 // -----------------------------------------------------------------------------
 
 .wallscreen.guided-tour {
-  .experience-subtitle {
-    margin-top: 0.2em;
-  }
-
-  .experience-attribution {
-    margin-top: 0.5em;
-  }
-
   .card-content {
     display: flex;
     flex-direction: column;
@@ -18,26 +10,12 @@
     justify-content: center;
   }
 
-  // half-width horizontal rule/border that appears after summary when on any
-  // slide except the first
-  &[data-guided-tour-index-value] {
-    .experience-summary::after {
-      display: block;
-      margin: 2em auto 0;
-      width: 50%;
-      content: "";
-      border-bottom: 1px solid #ddd;    
-    }
-  }
+  // small hr only shows when on slides after the first
   &[data-guided-tour-index-value="0"],
   &[data-guided-tour-index-value="1"] {
-    .experience-summary::after {
+    hr.small {
       display: none;
     }
-  }
-
-  .bio-card-area {
-    margin-top: 2em;
   }
   
   .bio-card {

--- a/_scss/wallscreens/experiences/_video.scss
+++ b/_scss/wallscreens/experiences/_video.scss
@@ -3,15 +3,6 @@
 // -----------------------------------------------------------------------------
 
 .wallscreen.oral-history {
-  .experience-subtitle {
-    margin-top: 0.4em;
-  }
-
-  .experience-attribution {
-    margin-top: .75em;
-    padding-bottom: 1.5em;
-  }
-
   .title-card {
     font-size: 34px;
     margin: 0 36px;


### PR DESCRIPTION
this PR addresses some problems with borders on cards & the modal: they had subtle variations in spacing/color, were tied to specific elements using padding/margin, and sometimes didn't appear if the sequence of elements wasn't right (e.g. no experience subtitle).

the new approach uses the `<hr/>` element so that borders can be explicitly inserted into the html, and are guaranteed to appear regardless of order/placement of surrounding elements. they are all styled using the same CSS.

relatedly, this PR removes some styles that hewed too closely to figma in favor of unifying margins across experiences (for example, the spacing between experience title and subtitle).

- Don't render empty experience subtitles
- Use horizontal rules for card/modal borders
- Globally unify margins/padding for hr
