### PR TITLE
Use GA debug mode for non-prod deployments

### DIFF
--- a/_includes/_analytics.html
+++ b/_includes/_analytics.html
@@ -4,6 +4,9 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
+  {% if jekyll.environment == 'production' %}
   gtag('config', 'G-0VWS29BZ43');
+  {% else %}
+  gtag('config', 'G-0VWS29BZ43', {'debug_mode': true});
+  {% endif %}
 </script>


### PR DESCRIPTION
fixes #121
mutually exclusive with #181 

opened this because i discovered an alternative way to separate development/production traffic, which seems in keeping with the "new" (v4) google analytics, and doesn't use the poorly documented "custom dimensions" feature. GA4 has what it calls ["data filters"](https://support.google.com/analytics/answer/10108813), which out of the box can look for "internal traffic" and "developer traffic". the former isn't meaningful to us, but the latter is interesting because it enables [the "debugview"](https://support.google.com/analytics/answer/7201382) (under "configure") which provides near-live feedback (see below screenshot).

this approach, which is simpler than #181, just turns on "debug mode" if `JEKYLL_ENV` isn't set to "production", which will mark all events triggered from that session/deploy as "developer traffic". for the moment this doesn't exclude them from analytics, but we can later change the filter's state to "active" if we want and it will exclude the traffic. even when traffic is excluded, you can still use the live debugview.

![Screen Shot 2021-11-10 at 10 04 21 AM](https://user-images.githubusercontent.com/4924494/141168467-8c942a45-9b54-4216-a8f9-002f375114fb.png)

