### PR TITLE
Give cards a bit more whitespace

### DIFF
--- a/_scss/wallscreens/_layout.scss
+++ b/_scss/wallscreens/_layout.scss
@@ -103,7 +103,7 @@ pre {
   display: flex;
   flex-direction: column;
   grid-area: card;
-  padding: 3rem;
+  padding: 4rem;
 }
 
 .card {


### PR DESCRIPTION
This will increase our text length problem a tiny bit, but I think adding a bit more whitespace between the content of the cards and the edges of the card area will improve the visual design. Specifically, this is more like a museum exhibit than a typical website so more whitespace is better, I think.

### Before

<img width="843" alt="Screen Shot 2021-11-10 at 4 15 25 PM" src="https://user-images.githubusercontent.com/101482/141209123-f9eb8696-33f9-48b0-a4b4-c15fad6ba48c.png">

### After
<img width="843" alt="Screen Shot 2021-11-10 at 4 12 24 PM" src="https://user-images.githubusercontent.com/101482/141209107-d29c29d1-bea2-4c64-ab2f-2056f9e9223c.png">


