### PR TITLE
Move slideshow caption to be adjacent to note field

### DIFF
--- a/_includes/_slideshow.html
+++ b/_includes/_slideshow.html
@@ -27,7 +27,6 @@
         <div id="{{ item.title | slugify }}" data-image-url="{% file_or_link {{item.local_image}} {{item.image}} %}" data-slideshow-target="slides">
 
           <h3 class="item-title">{{ item.title }}</h3>
-          <p class="item-caption">{{ item.caption }}</p>
           <div class="item-attribution">
             <span class="item-date">{{ item.date }}</span>
             <span class="separator">•</span>
@@ -36,6 +35,7 @@
           <div class="item-collection">{{ item.collection }}</div>
           <hr class="small"/>
 
+          <p class="item-caption">{{ item.caption }}</p>
           <p class="item-note">{{ item.note }}</p>
 
           {% if item.url %}


### PR DESCRIPTION
Weigh-in if you don't think this makes sense, but in the slideshow experience, displaying the caption directly beneath the item title has been bothering me. It feels more appropriate to display in conjunction with the note field, since those are the most descriptive fields for the image. Not all slideshows items include a caption field (e.g., video arcades) but I think this change will work in either case.

(I also want to talk to Henry about maybe removing the "From [photographer name] collection" field, since that info it is pretty clear from the experience title/subtitle in our existing experiences, which would further clean up these cards and make the after examples look better.)

### Before examples
<img width="409" alt="Screen Shot 2021-11-10 at 5 52 38 PM" src="https://user-images.githubusercontent.com/101482/141217657-1107978d-9cee-42c8-a7b8-625ddeb93f85.png">

---
<img width="409" alt="Screen Shot 2021-11-10 at 5 52 11 PM" src="https://user-images.githubusercontent.com/101482/141217687-b8f35673-2e00-4bf2-bb77-04338330b8d4.png">

### After examples

<img width="409" alt="Screen Shot 2021-11-10 at 5 43 19 PM" src="https://user-images.githubusercontent.com/101482/141217749-fae8b9a0-a75c-4990-b856-497e54e430cd.png">

---

<img width="409" alt="Screen Shot 2021-11-10 at 5 43 59 PM" src="https://user-images.githubusercontent.com/101482/141217771-d17bfa4b-704d-4e25-a57d-0cacdb9ec479.png">

