### PR TITLE
Make video thumbs smaller to accommodate 4 of them

### DIFF
--- a/_scss/wallscreens/experiences/_video.scss
+++ b/_scss/wallscreens/experiences/_video.scss
@@ -36,8 +36,8 @@
 
   .chapter-thumbnail {
     flex: none;
-    width: 3.75em;
-    height: 3.75em;
+    width: 3.25em;
+    height: 3.25em;
     border: 1px solid #979694;
     filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));
   }


### PR DESCRIPTION
Looking at today Hohbach Hall photos, I realized the video thumbnails, which fit well on the card when there are only 3 interview clips, won't accommodate 4 clips. One of the upcoming video experiences will have themes with 4 clips (I told the curators up to 4 clips per theme, if limited to 1 minute, would work, so this is my fault) so I shrunk down the thumbnail size a bit to fit 4 interview clips per card.

This solution works in device-mode but I think the physical screen doesn't quite match what I'm seeing locally, so I'm not certain this solution will be enough for the physical screen. But we can assess that with the next round of Hohbach Hall photos.

### Before - with a four clip added
<img width="409" alt="Screen Shot 2021-11-11 at 1 55 22 PM" src="https://user-images.githubusercontent.com/101482/141368882-242e221e-6ecd-4547-8ac9-576e64ff112e.png">



### After
<img width="409" alt="Screen Shot 2021-11-11 at 1 56 24 PM" src="https://user-images.githubusercontent.com/101482/141368914-5a0d091d-c977-406c-830e-80ecda4c342d.png">

