### PR TITLE
Add paragraph and button spacing in More Info modal

### DIFF
--- a/_scss/wallscreens/_modal.scss
+++ b/_scss/wallscreens/_modal.scss
@@ -16,7 +16,7 @@
   line-height: 1.5;
 
   > .inner {
-    padding: 2.75rem 8.75rem;
+    padding: 3rem 8.75rem 2rem;
     background-color: #f4f4f4;
     max-width: 90vw;
     max-height: 95vh;
@@ -36,6 +36,11 @@
     columns: 2;
     column-gap: 140px;
     margin-top: 0.9em;
+    orphans: 2;
+
+    p + p {
+      margin-top: 1rem;
+    }
   }
 
   h4 {
@@ -92,7 +97,7 @@
 
   .close {
     display: block;
-    margin: 1.5rem auto 0;
+    margin: 2.5rem auto 0;
     background-color: var(--color-primary-dark);
     color: white;
   }


### PR DESCRIPTION
A couple of small tweaks to improve readability and visual appearance of the more info modal:

- Add margin between paragraphs so they don't all visually run together
- Add a bit of top margin to the Close button to separate it a bit more from the nearby QR code

These increase the height of the modal, which I don't love, but it still fits okay? Some text editing could improve this but I'm not certain we'll get that here.

### Before

<img width="1435" alt="Screen Shot 2021-11-12 at 9 46 46 AM" src="https://user-images.githubusercontent.com/101482/141504093-2f806abe-23c9-436a-a3ee-b4cc0c96467c.png">

---

<img width="1435" alt="Screen Shot 2021-11-12 at 9 47 25 AM" src="https://user-images.githubusercontent.com/101482/141504126-354f15b0-cb30-41af-bd64-ccd43d76026b.png">

### After
<img width="1435" alt="Screen Shot 2021-11-12 at 9 45 18 AM" src="https://user-images.githubusercontent.com/101482/141504177-a8917258-4b40-4bc9-adbc-392658f61ad8.png">

---


<img width="1435" alt="Screen Shot 2021-11-12 at 9 45 10 AM" src="https://user-images.githubusercontent.com/101482/141504210-d96953f1-8d0e-4d5e-9ae4-8e8b4d5d12c7.png">

