### PR TITLE
Adjust typography of 'Explore Other' card heading

### DIFF
--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -100,21 +100,23 @@
   overflow: hidden;
   text-align: center;
   font-size: 1.25rem;
+  font-weight: bold;
   margin-top: 0;
+  text-transform: uppercase;
 
   &:before {
-    right: 0.5em;
+    right: 1em;
     margin-left: -50%;
   }
 
   &:after {
-    left: 0.5em;
+    left: 1em;
     margin-right: -50%;
   }
 
   &:before,
   &:after {
-    background-color: #ddd;
+    background-color: $su-color-black-20;
     content: "";
     display: inline-block;
     height: 1px;


### PR DESCRIPTION
Minor styling changes to:

- Restore the uppercase bold treatment of this heading (helps set it off from rest of the card content, imo)
- Darken the rule used with the heading (I could barely see it in the Hohbach Hall photos, so now it matches the color of the `<hr>` used elsewhere on the card. Though we might need to make these one step darker still...)
- Add a bit more whitespace between the rule ends and the heading text

### Before
<img width="421" alt="Screen Shot 2021-11-12 at 3 46 25 PM" src="https://user-images.githubusercontent.com/101482/141592155-41983cb6-a427-45dc-bc68-55343174f2c3.png">

### After


<img width="421" alt="Screen Shot 2021-11-12 at 4 04 47 PM" src="https://user-images.githubusercontent.com/101482/141593528-27565eaa-586b-4278-9c0c-45b7a47b0c4d.png">


