### PR TITLE
Reduce size of tour attractor image

### DIFF
--- a/_scss/wallscreens/attractors/_pan.scss
+++ b/_scss/wallscreens/attractors/_pan.scss
@@ -5,10 +5,10 @@
   background-position: 50% 50%;
   background-repeat: no-repeat;
   background-size: 120%;
-  height: 67vh;
+  height: 60vh;
   opacity: 0.7;
   overflow: hidden;
-  width: 58vw;
+  width: 51vw;
 }
 
 @keyframes panImage {


### PR DESCRIPTION
This is a minor change to make the guided tour images a bit smaller on the home, attractor screen. The goal is to make the attractor screen feel more like a preview, which I think making the image smaller and increasing the visible black background of the content area does.

@corylown I just reduced the `height` and `width` values, keeping the same proportion between them as before. The result  looks fine, so I assume it's okay but let me know if there's something about this strategy that isn't ideal, based on your knowledge from working on it.

### Before

<img width="1433" alt="Screen Shot 2021-11-15 at 2 12 36 PM" src="https://user-images.githubusercontent.com/101482/141855212-8b3fcf0c-a552-44e3-9e47-223d822847e6.png">

---


<img width="1433" alt="Screen Shot 2021-11-15 at 2 12 45 PM" src="https://user-images.githubusercontent.com/101482/141855414-248e6ca0-da3d-480b-b4f7-a63560b5d7bb.png">

### After


<img width="1433" alt="Screen Shot 2021-11-15 at 2 07 29 PM" src="https://user-images.githubusercontent.com/101482/141855429-b713dbd4-af2f-4657-968e-1d2ea7aaeab1.png">

---
<img width="1433" alt="Screen Shot 2021-11-15 at 2 06 44 PM" src="https://user-images.githubusercontent.com/101482/141855449-571175f8-b514-41f9-bf6a-d57d9d297ba2.png">


