### PR TITLE
Increase Dig Deeper element spacing

### DIFF
--- a/_includes/_dig_deeper.html
+++ b/_includes/_dig_deeper.html
@@ -2,6 +2,7 @@
 
 {% for item in experience.more_info %}
   <div class="dig-deeper-link">
-    <a href="{{ item.url }}" data-qr class="item-url">{{ item.type }}</a><span>{{ item.text }}
+    <a href="{{ item.url }}" data-qr class="item-url">{{ item.type }}</a>
+    <span>{{ item.text }}</span>
   </div>
 {% endfor %}

--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -52,7 +52,7 @@
   text-decoration: none;
   color: var(--color-primary);
   font-weight: 600;
-  gap: 1rem;
+  gap: 1.5rem;
   line-height: 1.5;
   margin-top: 1.25em;
 }
@@ -82,7 +82,7 @@
   margin-top: 1.5em;
   margin-bottom: 3rem;
   display: flex;
-  gap: 1rem;
+  gap: 2rem;
   font-size: 1.25rem;
   line-height: 1.5;
 


### PR DESCRIPTION
Very minor PR:

- Added missing `</span>` tag
- Increased slightly the gap between elements that are part of the final card QR code item

### Before


<img width="432" alt="Screen Shot 2021-11-17 at 11 31 59 AM" src="https://user-images.githubusercontent.com/101482/142262536-49ada30a-aed1-434b-891d-2efb9a50c2e1.png">


### After
<img width="432" alt="Screen Shot 2021-11-17 at 11 35 14 AM" src="https://user-images.githubusercontent.com/101482/142262556-1ffec0ed-7944-49a9-afb2-6d3d0f9f7853.png">


