### PR TITLE
First pass at styling interaction area buttons

### DIFF
--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -1,8 +1,8 @@
-$btn-border-radius: 4px !default;
+$btn-border-radius: 0.25rem !default;
 $btn-disabled-opacity: 0.8;
 $btn-box-shadow: inset 0 1px 0 rgba($su-color-white, .25), 0 4px 5px rgba($su-color-black-true, .25) !default;
 $btn-focus-box-shadow: 0 0 0 0.25rem rgba($su-color-black-true, 0.25) !default;
-$btn-active-box-shadow: inset 0 3px 5px rgba($su-color-black-true, .125) !default;
+$btn-active-box-shadow: inset 0px 0px 6px 1px rgba(130,0,0,0.2) !default;
 $btn-padding: .75em;
 $btn-padding-lg: 1.25em;
 $btn-font-family: "Source Sans Pro", sans-sans-serif;
@@ -46,14 +46,43 @@ button, .button {
     opacity: $btn-disabled-opacity;
   }
 
-  // buttons with more vertical padding and slightly larger font
+  // buttons with slightly larger font
   &.tall {
-    padding: $btn-padding-lg;
     font-size: 1.2rem; // ~18px
   }
 
   .fas {
     color: $su-color-stone-dark;
+  }
+}
+
+.experience-buttons,
+.secondary-buttons {
+  .button, button {
+    border-radius: 0.5rem;
+    color: $su-color-black;
+    font-weight: 600;
+    text-shadow: 0 3px 0 rgba(255,255,255,0.4);
+
+    &.active {
+      box-shadow: inset 0px 0px 6px 1px rgba(130,0,0,0.2);
+      color: $su-color-foggy-light;
+      text-shadow: 0 3px 0 rgba(0,0,0,0.2);
+    }
+  }
+}
+
+.experience-buttons .button {
+  box-shadow: inset 0px 0px 16px 4px rgba(0,0,0,0.15);
+  font-size: 1.3rem;
+  padding: 0.75em 1.25em;
+}
+
+.secondary-buttons {
+  .button, button {
+    box-shadow: inset 0px 0px 6px 1px rgba(0,0,0,0.2);
+    padding: 0.85em 1.25em;
+    text-transform: uppercase;
   }
 }
 


### PR DESCRIPTION
This PR updates the styling of (just) the interaction area buttons. I don't think this is as good as we can do, but it'll help me to see how this version looks on the physical wallscreen. In particular, I'm struggling to judge the best font sizes to keep everything in the right proportion.

I do think the button labels might be a bit too strong now, but we don't have a font-weight option between 400 (the before version) and 600 (the After version). The 400 just feels a bit anemic to me. I'd use 500 but I don't think it exists for Source Sans Pro?

Also, there's probably quite a bit of button-related SCSS refactoring we could do given the more specific styling done here, but I worry about trying to do that before finalizing everything. So maybe after all button styling is done, one of us can come back and remove unused button selectors, etc.

### Before

<img width="1282" alt="Screen Shot 2021-11-17 at 4 21 12 PM" src="https://user-images.githubusercontent.com/101482/142298632-005d2a2a-5513-415d-a911-9cc84ce85dd0.png">


### After

<img width="1282" alt="Screen Shot 2021-11-17 at 4 20 56 PM" src="https://user-images.githubusercontent.com/101482/142298650-bcdf956a-8d02-47e5-9d85-1e2bff771486.png">

