### PR TITLE
Move some summary text to new annotation box in Survival Conference tour

### DIFF
--- a/_data/experiences/survival-conference.yaml
+++ b/_data/experiences/survival-conference.yaml
@@ -5,7 +5,7 @@ title: Black Community Survival Conference
 subtitle:
 date: March 1972
 creator: Bob Fitch
-summary: Trained to be a Protestant minister, Bob Fitch's career as a photojournalist began in 1965 when he joined Reverend Martin Luther King Jr.'s organization, The Southern Christian Leadership Conference. As Fitch notes, "I worked for two intense years as the volunteer photographer for Dr. King and the SCLC, crisscrossing "Black Belt" states to document his people-to-people speaking tours promoting get-out-the-vote campaigns."
+summary: Trained to be a Protestant minister, Bob Fitch's career as a photojournalist began in 1965 when he joined Reverend Martin Luther King Jr.'s organization, The Southern Christian Leadership Conference. Fitch is best known for his work that captured iconic images of major figures of movements for civil rights, peace and social justice.
 short_summary: Trained to be a Protestant minister, Bob Fitch's career as a photojournalist began in 1965 when he joined Reverend Martin Luther King Jr.'s organization, The Southern Christian Leadership Conference. Fitch is best known for his work that captured iconic images of major figures of movements for civil rights, peace and social justice.
 
 more_info:
@@ -25,7 +25,7 @@ viewport:
   zoom: 1
 
 items:
-  - caption:
+  - caption: As Fitch notes, "I worked for two intense years as the volunteer photographer for Dr. King and the SCLC, crisscrossing "Black Belt" states to document his people-to-people speaking tours promoting get-out-the-vote campaigns."
   - key: slide-1
     caption: Huey Newton and Bobby Seale formed the Black Panther Party in Oakland, California, in 1966. The Black Panther Party was a revolutionary Black nationalist organization that instituted a variety of community social programs designed to alleviate poverty, combat police brutality, and improve health in Black communities. Bob Fitch captured the Black Panther Party's Black Community Survival Conference at Greenman Field in Oakland, California.
     viewport:


### PR DESCRIPTION
The card summary text was slightly different between the first card and the remaining cards, while the first tour stop had no annotation box. I moved the unique summary text from the first card to the first stop annotation box. So now the summary text is consistent across all tour stops and the first stop has some annotation text to read.

<img width="1280" alt="Screen Shot 2021-11-23 at 10 49 35 AM" src="https://user-images.githubusercontent.com/101482/143078142-f34cc9cc-f0f0-4451-800b-111fff29cf08.png">


