### PR TITLE
Adjust layout of 'dig deeper' links

### DIFF
--- a/_data/experiences/labor.yaml
+++ b/_data/experiences/labor.yaml
@@ -6,10 +6,10 @@ subtitle: "The David Bacon Photography Archive"
 summary: David Bacon (b. 1948) is a photojournalist, author, political activist, and union organizer who has focused on labor issues, particularly those related to immigrant labor. He has published several books, essays and articles on subjects including the history of the United Farm Workers; the working and living condition of farm workers in California; the work lives of workers; and many other topics. The images shown here have been selected from the David Bacon photography archive, circa 1985-2019, at Stanford.
 more_info:
   - type: Online Exhibit
-    text: Online Exhibit – The David Bacon Photography Archive at Stanford
+    text: The David Bacon Photography Archive at Stanford
     url: https://searchworks.stanford.edu/view/13156376
   - type: Catalog Record
-    text: Catalog Record - David Bacon photography archive, circa 1985-2019
+    text: David Bacon photography archive, circa 1985-2019
     url: https://searchworks.stanford.edu/view/13156376
   - type: Website
     text: "David Bacon: Stories, Photographs"

--- a/_includes/_dig_deeper.html
+++ b/_includes/_dig_deeper.html
@@ -1,8 +1,9 @@
 <h3 class="dig-deeper">Dig deeper</h3>
-
+<div class="dig-deeper-links">
 {% for item in experience.more_info %}
   <div class="dig-deeper-link">
     <a href="{{ item.url }}" data-qr class="item-url">{{ item.type }}</a>
     <span>{{ item.text }}</span>
   </div>
 {% endfor %}
+</div>

--- a/_includes/_dig_deeper.html
+++ b/_includes/_dig_deeper.html
@@ -2,8 +2,10 @@
 <div class="dig-deeper-links">
 {% for item in experience.more_info %}
   <div class="dig-deeper-link">
-    <a href="{{ item.url }}" data-qr class="item-url">{{ item.type }}</a>
-    <span>{{ item.text }}</span>
+    <a href="{{ item.url }}" data-qr class="item-url">
+      <span class="link-type">{{ item.type }}</span>
+    </a>
+    <span class="link-text">{{ item.text }}</span>
   </div>
 {% endfor %}
 </div>

--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -87,20 +87,20 @@
 
 .dig-deeper-link {
   display: block;
-  // width: 50%;
-  // display: flex;
-  // gap: 2rem;
   font-size: 1.25rem;
   line-height: 1.5;
 
   .item-url {
     align-items: flex-start;
-    width: 20ch;
     flex-shrink: 0;
     margin: 0;
   }
 
-  span {
+  .link-type {
+    margin-top: -0.3em;
+  }
+
+  .link-text {
     display: block;
     margin-top: 1em;
   }

--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -78,9 +78,14 @@
   }
 }
 
+.dig-deeper-links {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  margin: 2rem 0;
+}
+
 .dig-deeper-link {
-  margin-top: 1.5em;
-  margin-bottom: 3rem;
   display: flex;
   gap: 2rem;
   font-size: 1.25rem;

--- a/_scss/wallscreens/_cards.scss
+++ b/_scss/wallscreens/_cards.scss
@@ -79,15 +79,17 @@
 }
 
 .dig-deeper-links {
-  display: flex;
-  flex-direction: column;
-  gap: 2.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
   margin: 2rem 0;
 }
 
 .dig-deeper-link {
-  display: flex;
-  gap: 2rem;
+  display: block;
+  // width: 50%;
+  // display: flex;
+  // gap: 2rem;
   font-size: 1.25rem;
   line-height: 1.5;
 
@@ -96,6 +98,11 @@
     width: 20ch;
     flex-shrink: 0;
     margin: 0;
+  }
+
+  span {
+    display: block;
+    margin-top: 1em;
   }
 }
 


### PR DESCRIPTION
fixes #239

- Remove redundant link type from dig deeper link text
- Reduce margins on dig deeper links
- Move to grid-based dig deeper layout
- Align dig deeper link types with QR per @ggeisler

note that the two-column grid layout is sized appropriately on wallscreens (or it appears to be in the device emulator), but doesn't always have enough space on more normal screen sizes (e.g. my laptop).