### PR TITLE
Reduce size of attract mode images for guided tours for smoother animations

### DIFF
--- a/_data/experiences/ai-yamamoto-album.yaml
+++ b/_data/experiences/ai-yamamoto-album.yaml
@@ -21,8 +21,10 @@ more_info:
 # stitched image needs to be available on stacks
 image:
 local_image: local-media/Content/Image-Derivatives/Guided-Tour-1-Screen-11-Ai-Yamamoto/vg318sh2718_full.jpg
-# Needed so panning attract mode will work without a local image.
-stacks_image:
+
+attract_image:
+  image:
+  local_image: local-media/Content/Image-Derivatives/Guided-Tour-1-Screen-11-Ai-Yamamoto/vg318sh2718_attract.jpg
 
 viewport:
   zoom: 1

--- a/_data/experiences/medical-devices.yaml
+++ b/_data/experiences/medical-devices.yaml
@@ -18,8 +18,10 @@ more_info:
 
 image: https://stacks.stanford.edu/image/iiif/xh842zs4872%2Fxh842zs4872_0001/info.json
 local_image: local-media/Content/Image-Derivatives/Guided-Tour-1-Medical-Devices/xh842zs4872_full.jpg
-# Needed so panning attract mode will work without a local image.
-stacks_image: https://stacks.stanford.edu/image/iiif/xh842zs4872%2Fxh842zs4872_0001/290,290,12000,8000/max/0/default.jpg
+
+attract_image:
+  image: https://stacks.stanford.edu/image/iiif/xh842zs4872%2Fxh842zs4872_0001/290,290,12000,8000/max/0/default.jpg
+  local_image: local-media/Content/Image-Derivatives/Guided-Tour-1-Medical-Devices/xh842zs4872_attract.jpg
 
 viewport:
   zoom: 1

--- a/_data/experiences/networking.yaml
+++ b/_data/experiences/networking.yaml
@@ -19,8 +19,10 @@ more_info:
 
 image: https://stacks.stanford.edu/image/iiif/gb738dt2052%2Fgb738dt2052_0001/info.json
 local_image: local-media/Content/Image-Derivatives/Guided-Tour-2-Computer-Networking/gb738dt2052_full.jpg
-# Needed so panning attract mode will work without a local image.
-stacks_image: https://stacks.stanford.edu/image/iiif/gb738dt2052/gb738dt2052_0001/290,290,12000,8000/max/0/default.jpg
+
+attract_image:
+  image: https://stacks.stanford.edu/image/iiif/gb738dt2052/gb738dt2052_0001/290,290,12000,8000/max/0/default.jpg
+  local_image: local-media/Content/Image-Derivatives/Guided-Tour-2-Computer-Networking/gb738dt2052_attract.jpg
 
 viewport:
   zoom: 1

--- a/_data/experiences/survival-conference.yaml
+++ b/_data/experiences/survival-conference.yaml
@@ -18,8 +18,10 @@ more_info:
 
 image: https://stacks.stanford.edu/image/iiif/jg905yx8933%2F003_panther_00005_FX/info.json
 local_image: local-media/Content/Image-Derivatives/Guided-Tour-2-Screen-11-Black-Community-Survival-Conference/jg905yx8933_full.jpg
-# Needed so panning attract mode will work without a local image.
-stacks_image: https://stacks.stanford.edu/image/iiif/jg905yx8933%2F003_panther_00005_FX/full/max/0/default.jpg
+
+attract_image:
+  image: https://stacks.stanford.edu/image/iiif/jg905yx8933%2F003_panther_00005_FX/full/max/0/default.jpg
+  local_image: local-media/Content/Image-Derivatives/Guided-Tour-2-Screen-11-Black-Community-Survival-Conference/jg905yx8933_attract.jpg
 
 viewport:
   zoom: 1

--- a/_includes/experiences/_guided_tour.html
+++ b/_includes/experiences/_guided_tour.html
@@ -30,7 +30,7 @@
     <div class="caption" data-guided-tour-target="caption"></div>
   </div>
   <div class="attract-mode-pan" data-guided-tour-target="attractPanContainer">
-    <div class="attract-image" style="background-image: url({% file_or_link {{experience.local_image}} {{experience.stacks_image}} %})"></div>
+    <div class="attract-image" style="background-image: url({% file_or_link {{experience.attract_image.local_image}} {{experience.attract_image.image}} %})"></div>
   </div>
 </main>
 

--- a/_layouts/guided_tour_index.html
+++ b/_layouts/guided_tour_index.html
@@ -9,6 +9,6 @@ experience_type: guided_tour
 
 <main class="content-area">
   <div class="attract-mode-pan">
-    <div class="attract-image" style="background-image: url({% file_or_link {{experience.local_image}} {{experience.stacks_image}} %})"></div>
+    <div class="attract-image" style="background-image: url({% file_or_link {{experience.attract_image.local_image}} {{experience.attract_image.image}} %})"></div>
   </div>
 </main>


### PR DESCRIPTION
Adds separate, smaller image derivatives specifically for the panning attract page for guided tours. I've added these smaller derivatives (under 10MB) to the google drive.

```
Content/Image-Derivatives/Guided-Tour-1-Medical-Devices/xh842zs4872_attract.jpg
Content/Image-Derivatives/Guided-Tour-1-Screen-11-Ai-Yamamoto/vg318sh2718_attract.jpg
Content/Image-Derivatives/Guided-Tour-2-Computer-Networking/gb738dt2052_attract.jpg
Content/Image-Derivatives/Guided-Tour-2-Screen-11-Black-Community-Survival-Conference/jg905yx8933_attract.jpg
```

Closes #234 