### PR TITLE
Minor text updates to med tech oral history

### DIFF
--- a/_data/experiences/medical-technology.yaml
+++ b/_data/experiences/medical-technology.yaml
@@ -1,5 +1,5 @@
 key: medical-technology
-title: "Medicine and Innovation: Oral Histories and Archive of Medical Technology"
+title: "Medicine and Innovation"
 subtitle: "Excerpts from <i>Medicine and Innovation: Oral Histories and Archive of Medical Technology</i>"
 date: 2019 - 2021
 creator: Henry Lowood & Paul Yock
@@ -37,15 +37,15 @@ items:
     timestamp: 0
     class: hidden-theme-title
   - key: john-simpson
-    title: From interview with John Simpson, October 16, 2019.
+    title: From interview with John Simpson, October 16, 2019
     theme: Getting Started
     timestamp: 5
   - key: thomas-j-fogarty
-    title: From interview with Thomas J. Fogarty, April 4, 2019.
+    title: From interview with Thomas J. Fogarty, April 4, 2019
     theme: Getting Started
     timestamp: 56
   - key: lisa-earnhardt
-    title: From interview with Lisa Earnhardt, October 8, 2020.
+    title: From interview with Lisa Earnhardt, October 8, 2020
     theme: Getting Started
     timestamp: 125
   - key: title-2
@@ -54,15 +54,15 @@ items:
     timestamp: 185
     class: hidden-theme-title
   - key: fred-khosravi
-    title: From interview with Fred Khosravi, May 21, 2021.
+    title: From interview with Fred Khosravi, May 21, 2021
     theme: A Challenging Problem
     timestamp: 190
   - key: ginger-l-graham
-    title: From interview with Ginger L. Graham, January 27, 2020.
+    title: From interview with Ginger L. Graham, January 27, 2020
     theme: A Challenging Problem
     timestamp: 273
   - key: mir-imran
-    title: From interview with Mir Imran, March 30, 2021.
+    title: From interview with Mir Imran, March 30, 2021
     theme: A Challenging Problem
     timestamp: 372
   - key: title-3
@@ -71,14 +71,14 @@ items:
     timestamp: 455
     class: hidden-theme-title
   - key: ginger-l-graham-2
-    title: From interview with Ginger L. Graham, January 27, 2020.
+    title: From interview with Ginger L. Graham, January 27, 2020
     theme: The Impact on Medical Care
     timestamp: 461
   - key: lisa-earnhardt-2
-    title: From interview with Lisa Earnhardt, October 8, 2020.
+    title: From interview with Lisa Earnhardt, October 8, 2020
     theme: The Impact on Medical Care
     timestamp: 505
   - key: fred-khosravi-2
-    title: From interview with Fred Khosravi, May 21, 2021.
+    title: From interview with Fred Khosravi, May 21, 2021
     theme: The Impact on Medical Care
     timestamp: 583


### PR DESCRIPTION
The curators provided some info in the spreadsheet that we discussed in our meeting last week but the spreadsheet wasn't updated. So this PR just addresses two text issues that the curators agreed would be okay to fix:

- Shorten title of the experience so the summary text doesn't hit the start button
- Remove periods from the end of the "From interview..." lines

### Before

<img width="439" alt="Screen Shot 2021-11-24 at 12 28 25 PM" src="https://user-images.githubusercontent.com/101482/143302505-e044afd9-e13f-444d-9fc1-e5faf10fc41e.png">


### After
<img width="439" alt="Screen Shot 2021-11-24 at 12 29 42 PM" src="https://user-images.githubusercontent.com/101482/143302510-53157c5c-f02f-4b43-a603-4fe7a8fc48e5.png">


