### PR TITLE
Add html-proofer to CI steps.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,5 +26,5 @@ jobs:
       run: |
         bundle config path vendor/bundle
         bundle install
-    - name: Run Rubocop
-      run: bundle exec rubocop
+    - name: Run CI
+      run: bundle exec rake ci

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,5 @@ AllCops:
   NewCops: enable
   Exclude:
     - '_site/*'
-    - 'Rakefile'
     - vendor/bundle/**/*
+  SuggestExtensions: false

--- a/Gemfile
+++ b/Gemfile
@@ -37,4 +37,6 @@ gem 'webrick', '~> 1.7'
 
 gem 'sass-embedded'
 
+gem 'html-proofer'
+gem 'rake'
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,20 @@ GEM
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.15.4)
     forwardable-extended (2.6.0)
     google-protobuf (3.19.0-x86_64-darwin)
+    html-proofer (3.19.2)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -53,13 +63,19 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogumbo (2.0.5)
+      nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.21.0)
     parser (3.0.3.1)
       ast (~> 2.4.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
+    racc (1.6.0)
     rainbow (3.0.0)
+    rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -85,8 +101,11 @@ GEM
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
+    yell (2.2.2)
 
 PLATFORMS
   x86_64-darwin-19
@@ -94,9 +113,11 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  html-proofer
   jekyll (~> 4.2.1)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
+  rake
   rubocop
   sass-embedded
   tzinfo (~> 1.2)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'html-proofer'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new(:rubocop)
+
+desc 'Build site and run html-proofer'
+task :html_proofer do
+  sh 'bundle exec jekyll build'
+  options = { alt_ignore: [/.*/],
+              assume_extension: true,
+              check_html: true,
+              disable_external: true,
+              report_invalid_tags: true }
+  HTMLProofer.check_directory('./_site', options).run
+end
+
+desc 'Run the full set of CI tasks'
+task :ci do
+  Rake::Task['rubocop'].invoke
+  Rake::Task['html_proofer'].invoke
+end


### PR DESCRIPTION
Not sure if this is good idea or not, but running an HTML linter seems to be something people do with generated sites. Also moves CI related tasks to Rakefile. Partially addresses #277 