### PR TITLE
Add autoplay control button

### DIFF
--- a/_includes/_nav_card.html
+++ b/_includes/_nav_card.html
@@ -1,4 +1,19 @@
-<nav class="card-nav" data-{{ layout.controller }}-target="nav">
-  <button class="button" data-action="{{ layout.controller }}#previous"><i class="fas fa-arrow-alt-circle-left"></i> <span>Previous</span></button>
-  <button class="button" data-action="{{ layout.controller }}#next"><span>Next</span> <i class="fas fa-arrow-alt-circle-right"></i></button>
+<nav class="card-nav">
+  <button class="button" data-action="{{ layout.controller }}#previous">
+    <i class="fas fa-arrow-alt-circle-left"></i>
+    <span>Previous</span>
+  </button>
+  {% if layout.autoplay %}
+  <button class="button autoplay" data-action="{{ layout.controller }}#toggleAutoplay" data-{{ layout.controller }}-target="autoplayButton">
+    <i class="fas fa-play"></i>
+    <i class="fas fa-pause"></i>
+    <svg class="progress-ring" viewBox="0 0 100 100">
+      <circle cx="50" cy="50" r="45"></circle>
+    </svg>
+  </button>
+  {% endif %}
+  <button class="button" data-action="{{ layout.controller }}#next">
+    <span>Next</span>
+    <i class="fas fa-arrow-alt-circle-right"></i>
+  </button>
 </nav>

--- a/_layouts/experience.html
+++ b/_layouts/experience.html
@@ -14,7 +14,7 @@ stylesheet: css/wallscreen.scss
     {% when 'oral-history' %}
     data-action="more-info:show->oral-history#pause more-info:hide->oral-history#unpause more-info:show->oral-history#resetAutoplayTimer more-info:hide->oral-history#resetAutoplayTimer"
     {% else %}
-    data-action="click@document->{{ layout.controller }}#resetAutoplayTimer"
+    data-action="more-info:show->{{ layout.controller }}#pauseAutoplay click@document->{{ layout.controller }}#resetAutoplayTimer"
   {% endcase %}
   {% endif %}>
 

--- a/_layouts/guided_tour.html
+++ b/_layouts/guided_tour.html
@@ -5,6 +5,7 @@ items_label: stops
 explore_label: guided tours
 index_page: guided-tours
 controller: guided-tour
+autoplay: true
 ---
 
 {% assign experience = site.data.experiences[page.experience] %}

--- a/_layouts/slideshow.html
+++ b/_layouts/slideshow.html
@@ -5,6 +5,7 @@ items_label: images
 explore_label: slideshows
 index_page: slideshows
 controller: slideshow
+autoplay: true
 ---
 
 {% assign experience = site.data.experiences[page.experience] %}

--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -169,7 +169,7 @@ button, .button {
   padding: 0;
   justify-content: center;
   position: relative;
-  min-width: 2.75rem; // chrome ignores aspect-ratio here for some reason
+  min-width: 3.09375rem; // chrome ignores aspect-ratio here for some reason
 
   // by default, hide pause icon/progress indicator
   .fa-pause,

--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -214,7 +214,7 @@ button, .button {
 
     // animation time should match configured autoplayInterval in controller
     .progress-ring circle {
-      animation: ringFill 60s linear infinite;
+      animation: ringFill 15s linear infinite;
     }
   }
 }

--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -6,6 +6,7 @@ $btn-active-box-shadow: inset 0px 0px 6px 1px rgba(130,0,0,0.2) !default;
 $btn-padding: .75em;
 $btn-padding-lg: 1.25em;
 $btn-font-family: "Open Sans", sans-sans-serif;
+$btn-circumference: 45 * 2 * 3.141592653589793;   // = 2 * pi * r; for autoplay
 
 button, .button {
   font-size: 1.125rem;  // 16px; change this to rescale the button
@@ -162,6 +163,61 @@ button, .button {
   }
 }
 
+.autoplay.button {
+  border-radius: 100%;
+  aspect-ratio: 1;
+  padding: 0;
+  justify-content: center;
+  position: relative;
+
+  // by default, hide pause icon/progress indicator
+  .fa-pause,
+  .progress-ring {
+    display: none;
+  }
+
+  // radial progress indicator (embedded svg); inspired by
+  // https://css-tricks.com/building-progress-ring-quickly/
+  .progress-ring {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+
+    circle {
+      fill: transparent;
+      stroke: var(--color-primary);
+      stroke-width: 10;   // 2 * (cx - r)
+      stroke-dasharray: $btn-circumference $btn-circumference;
+      transform: rotate(-90deg);  // "right" is 0deg for svg; we want "up"
+      transform-origin: 50% 50%;
+    }
+  }
+
+  // controller applies this class when autoplay is active
+  &.active {
+    // revert normal button active styling
+    background-color: var(--color-secondary);
+    box-shadow: $btn-box-shadow;
+
+    // hide play icon and show pause icon/progress indicator
+    .fa-play {
+      display: none;
+    }
+
+    .fa-pause,
+    .progress-ring {
+      display: block;
+    }
+
+    // animation time should match configured autoplayInterval in controller
+    .progress-ring circle {
+      animation: ringFill 60s linear infinite;
+    }
+  }
+}
+
 @keyframes slowPulse {
 	0% {
 		box-shadow: 0 0 0 0 rgba(130, 0, 0, 0.5);
@@ -183,4 +239,14 @@ button, .button {
   font-weight: 600;
   padding: 0.75em 1em;
   text-align: center;
+}
+
+@keyframes ringFill {
+  0% {
+    stroke-dashoffset: $btn-circumference;
+  }
+
+  100% {
+    stroke-dashoffset: 0;
+  }
 }

--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -169,6 +169,7 @@ button, .button {
   padding: 0;
   justify-content: center;
   position: relative;
+  min-width: 2.75rem; // chrome ignores aspect-ratio here for some reason
 
   // by default, hide pause icon/progress indicator
   .fa-pause,

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -52,7 +52,6 @@ export default class extends Controller {
 
   // (re)set a timer for entering the autoplay after an idle timeout
   resetAutoplayTimer() {
-    if (this.autoplaying) window.clearInterval(this.autoplayInterval);
     if (this.autoplayTimer) window.clearTimeout(this.autoplayTimer);
 
     if (this.indexValue == 0 && !this.nextValue) return;

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -73,12 +73,24 @@ export default class extends Controller {
   next() {
     this.indexValue = Math.min(this.indexValue + 1, this.slidesTargets.length - 1);
     gtag('event', 'next', { index: this.indexValue });
+
+    // restart autoplay interval if playing
+    if (this.autoplaying) {
+      this.pauseAutoplay();
+      window.setTimeout(() => this.autoplay(), 1);  
+    }
   }
 
   // paginate to the previous slide, or the intro card
   previous() {
     this.indexValue = Math.max(this.indexValue - 1, 0);
     gtag('event', 'previous', { index: this.indexValue });
+
+    // restart autoplay interval if playing
+    if (this.autoplaying) {
+      this.pauseAutoplay();
+      window.setTimeout(() => this.autoplay(), 1);  
+    }
   }
 
   get ended() {

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -73,14 +73,12 @@ export default class extends Controller {
   next() {
     this.indexValue = Math.min(this.indexValue + 1, this.slidesTargets.length - 1);
     gtag('event', 'next', { index: this.indexValue });
-    this.pauseAutoplay();
   }
 
   // paginate to the previous slide, or the intro card
   previous() {
     this.indexValue = Math.max(this.indexValue - 1, 0);
     gtag('event', 'previous', { index: this.indexValue });
-    this.pauseAutoplay();
   }
 
   get ended() {

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -69,11 +69,6 @@ export default class extends Controller {
     this.autoplay();
   }
 
-  // reset the slideshow back to the intro card
-  reset() {
-    this.indexValue = 0;
-  }
-
   // paginate to the next slide, or the end card
   next() {
     this.indexValue = Math.min(this.indexValue + 1, this.slidesTargets.length - 1);

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -67,6 +67,7 @@ export default class extends Controller {
   start() {
     this.indexValue = 1;
     gtag('event', 'start-tour');
+    this.autoplay();
   }
 
   // reset the slideshow back to the intro card

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   static targets = ['slides', 'caption', 'slideContainer', 'guidedTourMainContent', 'attractPanContainer', 'autoplayButton'];
 
   static autoplayTimeout = 5 * 60 * 1000; // 5 minutes
-  
+
   static autoplayIntervalTime = 15 * 1000; // 15 seconds per stop in autoplay mode
 
   static crossFadeTime = 1000; // 1 second
@@ -77,7 +77,7 @@ export default class extends Controller {
     // restart autoplay interval if playing
     if (this.autoplaying) {
       this.pauseAutoplay();
-      window.setTimeout(() => this.autoplay(), 1);  
+      window.setTimeout(() => this.autoplay(), 1);
     }
   }
 
@@ -89,7 +89,7 @@ export default class extends Controller {
     // restart autoplay interval if playing
     if (this.autoplaying) {
       this.pauseAutoplay();
-      window.setTimeout(() => this.autoplay(), 1);  
+      window.setTimeout(() => this.autoplay(), 1);
     }
   }
 
@@ -106,8 +106,7 @@ export default class extends Controller {
     if (this.autoplaying) {
       gtag('event', 'pause-autoplay');
       this.pauseAutoplay();
-    }
-    else {
+    } else {
       gtag('event', 'start-autoplay');
       this.autoplay();
     }

--- a/js/controllers/guided-tour.js
+++ b/js/controllers/guided-tour.js
@@ -6,8 +6,8 @@ export default class extends Controller {
   static targets = ['slides', 'caption', 'slideContainer', 'guidedTourMainContent', 'attractPanContainer', 'autoplayButton'];
 
   static autoplayTimeout = 5 * 60 * 1000; // 5 minutes
-
-  static autoplayIntervalTime = 1 * 60 * 1000; // 1 minute per slide in autoplay mode
+  
+  static autoplayIntervalTime = 15 * 1000; // 15 seconds per stop in autoplay mode
 
   static crossFadeTime = 1000; // 1 second
 

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   static autoplayTimeout = 5 * 60 * 1000; // 5 minutes
 
   static autoplayIntervalTime = 15 * 1000; // 15 seconds per slide in autoplay mode
-  
+
   static crossFadeTime = 1000; // 1 second
 
   connect() {
@@ -73,7 +73,7 @@ export default class extends Controller {
     // restart autoplay interval if playing
     if (this.autoplaying) {
       this.pauseAutoplay();
-      window.setTimeout(() => this.autoplay(), 1);  
+      window.setTimeout(() => this.autoplay(), 1);
     }
   }
 
@@ -85,7 +85,7 @@ export default class extends Controller {
     // restart autoplay interval if playing
     if (this.autoplaying) {
       this.pauseAutoplay();
-      window.setTimeout(() => this.autoplay(), 1);  
+      window.setTimeout(() => this.autoplay(), 1);
     }
   }
 
@@ -102,8 +102,7 @@ export default class extends Controller {
     if (this.autoplaying) {
       gtag('event', 'pause-autoplay');
       this.pauseAutoplay();
-    }
-    else {
+    } else {
       gtag('event', 'start-autoplay');
       this.autoplay();
     }

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -7,8 +7,8 @@ export default class extends Controller {
 
   static autoplayTimeout = 5 * 60 * 1000; // 5 minutes
 
-  static autoplayIntervalTime = 1 * 60 * 1000; // 1 minute per slide in autoplay mode
-
+  static autoplayIntervalTime = 15 * 1000; // 15 seconds per slide in autoplay mode
+  
   static crossFadeTime = 1000; // 1 second
 
   connect() {

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -69,14 +69,12 @@ export default class extends Controller {
   next() {
     this.indexValue = Math.min(this.indexValue + 1, this.slidesTargets.length - 1);
     gtag('event', 'next', { index: this.indexValue });
-    this.pauseAutoplay();
   }
 
   // paginate to the previous slide, or the intro card
   previous() {
     this.indexValue = Math.max(this.indexValue - 1, 0);
     gtag('event', 'previous', { index: this.indexValue });
-    this.pauseAutoplay();
   }
 
   get ended() {

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -65,11 +65,6 @@ export default class extends Controller {
     this.autoplay();
   }
 
-  // reset the slideshow back to the intro card
-  reset() {
-    this.indexValue = 0;
-  }
-
   // paginate to the next slide, or the end card
   next() {
     this.indexValue = Math.min(this.indexValue + 1, this.slidesTargets.length - 1);

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -48,7 +48,6 @@ export default class extends Controller {
 
   // (re)set a timer for entering the autoplay after an idle timeout
   resetAutoplayTimer() {
-    if (this.autoplaying) window.clearInterval(this.autoplayInterval);
     if (this.autoplayTimer) window.clearTimeout(this.autoplayTimer);
 
     if (this.indexValue == 0 && !this.nextValue) return;

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -63,6 +63,7 @@ export default class extends Controller {
   start() {
     this.indexValue = 1;
     gtag('event', 'start-slideshow');
+    this.autoplay();
   }
 
   // reset the slideshow back to the intro card

--- a/js/controllers/slideshow.js
+++ b/js/controllers/slideshow.js
@@ -69,12 +69,24 @@ export default class extends Controller {
   next() {
     this.indexValue = Math.min(this.indexValue + 1, this.slidesTargets.length - 1);
     gtag('event', 'next', { index: this.indexValue });
+
+    // restart autoplay interval if playing
+    if (this.autoplaying) {
+      this.pauseAutoplay();
+      window.setTimeout(() => this.autoplay(), 1);  
+    }
   }
 
   // paginate to the previous slide, or the intro card
   previous() {
     this.indexValue = Math.max(this.indexValue - 1, 0);
     gtag('event', 'previous', { index: this.indexValue });
+
+    // restart autoplay interval if playing
+    if (this.autoplaying) {
+      this.pauseAutoplay();
+      window.setTimeout(() => this.autoplay(), 1);  
+    }
   }
 
   get ended() {


### PR DESCRIPTION
closes #286
branched from #283 since I didn't want to end up redoing work to reference layouts (and hence draft).

this implementation adds a small play/pause button to control autoplay with a "ring" indicator of how much time is left until the next slide/step. if you advance the slide manually or otherwise interact with the page, the autoplay should deactivate. eventually (after `autoplayTimeout` elapses without any interaction) it will turn back on again on its own.

note that if you want to test with shorter timer values, you also need to change the CSS that controls the "ring" animation:
https://github.com/sul-dlss/wallscreens/blob/89daf9f6941ddc6b1c91e179b0f00a58be24aa7f/_scss/wallscreens/_buttons.scss#L202-L205

this could be made "smarter" (we could actually update the ring to match the interval) but i went with a "dumb" version for the first pass where the animation doesn't actually know about the timer, it just runs for a set amount of time. it seems to work OK.