### PR TITLE
Update font and styling of experience start buttons

### DIFF
--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -87,19 +87,11 @@ button, .button {
   }
 }
 
-.button.select-button {
-  margin-bottom: 0.5em;
-
-  .fa-arrow-alt-circle-right {
-    padding-bottom: 0.25em;
-  }
-}
-
 .button.select-button, .button.start-button {
   border-radius: 1rem;
   box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5);
   padding: 0.75em 1.75em 0.5em 2.25em;
-
+  
   .select-experience, .begin-experience {
     color: $su-color-cardinal-red-dark;
     font-size: 1.25rem;
@@ -107,6 +99,25 @@ button, .button {
     padding-bottom: 0.25em;
     text-shadow: 0 3px 0 rgba(255, 255, 255, 0.4);
     text-transform: uppercase;
+  }
+}
+
+.button.select-button {
+  border-radius: 0.33rem;
+  box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.3);
+  margin-bottom: 0.5em;
+  padding: 0.75em 1.75em 0.5em 2em;
+
+  .select-experience {
+    font-family: 'Rajdhani', 'Open Sans', sans-serif;
+    font-size: 1.6rem;
+    padding-bottom: 0;
+    text-transform: none;
+  }
+
+  .fa-arrow-alt-circle-right {
+    font-size: 1.4rem;
+    margin-left: 0.25rem;
   }
 }
 


### PR DESCRIPTION
When we added the new experience navigation layer, we just sort of reused the "Touch to start" button styling to use for the experience start buttons. After looking at the index pages a lot, it felt to me that the styling that works for the "Touch to start" button is sort of overkill for the experience start buttons, especially since there are usually more than one of them visible at a time.

So this PR just restyles the experience start buttons, and includes switching them to use the new display font. This will result in the same font being used for both the experience start button and the card title of the experience, which seems good for continuity.

Some after examples:

<img width="1287" alt="Screen Shot 2021-12-09 at 1 00 00 PM" src="https://user-images.githubusercontent.com/101482/145468153-2c299bfb-469d-4f58-8dcc-8978e11262de.png">

---

<img width="1287" alt="Screen Shot 2021-12-09 at 1 00 11 PM" src="https://user-images.githubusercontent.com/101482/145468194-24346edb-5e20-46c0-bc77-d958eb33b41b.png">

---

<img width="1287" alt="Screen Shot 2021-12-09 at 1 00 33 PM" src="https://user-images.githubusercontent.com/101482/145468205-89d2bfdd-b7b8-4671-9504-c16aabfb8ff6.png">

---

<img width="1287" alt="Screen Shot 2021-12-09 at 1 00 39 PM" src="https://user-images.githubusercontent.com/101482/145468212-0ccf078d-3c0d-4f76-8afd-76a5513e1f18.png">


