### PR TITLE
Update button label and experience subtitle

### DIFF
--- a/_data/experiences/african-american-histories.yaml
+++ b/_data/experiences/african-american-histories.yaml
@@ -1,6 +1,6 @@
 key: african-american-histories
 title: African American Histories
-subtitle: "Excerpts from the collection: <i>African American Histories in Silicon Valley, 2019 – 2021</i>"
+subtitle: "Excerpts from the collection: <i>African American Histories in Silicon Valley, 2019&nbsp;–&nbsp;2021</i>"
 date: 2019-2021
 creator: Henry Lowood
 extent: 8 interviews

--- a/_data/experiences/medical-technology.yaml
+++ b/_data/experiences/medical-technology.yaml
@@ -8,7 +8,7 @@ duration: 11 minutes
 type: oral_history
 # file:
 local_file: local-media/20211118_2700x1800_MedicalTechnology_25mbps_wallscreen_29.97fps_v1.3.mp4
-button_label: Medical Technology
+button_label: Medicine and Innovation
 summary: The Medicine and Innovation collection of oral history interviews presents the history of medical device technology, with a focus on inventors, entrepreneurs and investors in Silicon Valley. While medical technology is perhaps not as frequently associated with this region as biotechnology, it is nevertheless an area in which Stanford University and companies located in the Valley have played a leading role. In collaboration with the Stanford Byers Center for Biodesign, the Silicon Valley Archives is producing these interviews to provide the perspectives and stories of those who built an industry that today is represented by hundreds of companies in Northern California.
 # more_info:
 #   - type:


### PR DESCRIPTION
Two minor updates:

- Changed the Medical oral history button label to match the experience title (since it fits easily as a button label now)
- Added some non-breaking spaces to the AAH subtitle, because we were getting an ugly line break. This seems safe to do because I don't think we show the experience title in any other context (and if we did, we'd probably want the years to stay together like this there, too):

<img width="427" alt="Screen Shot 2021-12-09 at 3 46 50 PM" src="https://user-images.githubusercontent.com/101482/145488308-33883b1e-885e-4915-b990-516fcaccf777.png">

### After

<img width="427" alt="Screen Shot 2021-12-09 at 3 47 13 PM" src="https://user-images.githubusercontent.com/101482/145488331-00956fa5-554a-4709-ae73-4ab4387a35d1.png">

