### PR TITLE
Specify slideshow attract images

### DIFF
--- a/_data/experiences/adobe-and-apple.yaml
+++ b/_data/experiences/adobe-and-apple.yaml
@@ -11,6 +11,16 @@ more_info:
   - type: Digital Exhibit
     text: Douglas Menuez Photography Collection
     url: https://exhibits.stanford.edu/menuez
+attract_images:
+  - a-business-partnership
+  - adobe-design
+  - marketing
+  - the-boston-launch
+  - apple-in-transition
+  - the-newton
+  - warnock-and-geschke
+  - kanji-printer-products
+  - adobe
 items:
   - key: adobe
     url: https://purl.stanford.edu/kq505ns0185

--- a/_data/experiences/labor.yaml
+++ b/_data/experiences/labor.yaml
@@ -14,6 +14,16 @@ more_info:
   - type: Website
     text: "David Bacon: Stories, Photographs"
     url: http://dbacon.igc.org/
+attract_images:
+  - workers-assemble-2
+  - farm-workers
+  - workers-assemble-7
+  - gonzalez
+  - housekeeper
+  - united-farm-workers
+  - workers-assemble-6
+  - homeless-couple
+  - building-trades
 items:
   - key: workers-assemble
     title: Workers assemble Toyota Corollas at the New United Motor Manufacturing plant

--- a/_data/experiences/richard-weiland.yaml
+++ b/_data/experiences/richard-weiland.yaml
@@ -17,12 +17,12 @@ more_info:
 attract_images:
   - ric-weiland
   - development
-  - commencement
+  - microsoft
   - diary-3
   - license-plate
-  - microsoft
-  - personal-notes-2
+  - commencement
   - albuquerque
+  - diary-2
   - weiland-gates
 items:
   - key: ric-weiland

--- a/_data/experiences/video-arcades.yaml
+++ b/_data/experiences/video-arcades.yaml
@@ -8,7 +8,16 @@ more_info:
   - type: Collection
     text: Ira Nowinski photograph collection, ca. 1965-2016
     url: https://searchworks.stanford.edu/view/4712540
-
+attract_images:
+  - asteroids-1
+  - berkeley-2
+  - sf-arcade-2
+  - broadway-arcade
+  - sf-arcade-1
+  - santa-cruz-1
+  - san-mateo-3
+  - asteroids-4
+  - pier-39-3
 items:
   - key: sf-arcade-1
     title: 1st Street Arcade San Francisco


### PR DESCRIPTION
With the manual method of specifying slideshow index page attract images set up (thanks, I think this is very handy and it makes it super easy to change out or move around images), in this PR I specified the images for the various slideshows (and changed my mind about a few Weiland ones I had previously specified).