### PR TITLE
Add missing slideshow image title

### DIFF
--- a/_data/experiences/richard-weiland.yaml
+++ b/_data/experiences/richard-weiland.yaml
@@ -146,7 +146,7 @@ items:
     image: https://stacks.stanford.edu/image/iiif/bc911qv7911%2Fbc911qv7911/full/max/0/default.jpg
     local_image: local-media/Content/Image-Derivatives/Slideshow-2-Screen-11-Richard-Weiland/bc911qv7911.jpg
   - key: personal-notes-2
-    title:
+    title: Halloween
     caption:
     date: 1996
     creator: Richard William Weiland


### PR DESCRIPTION
Replaced (or added, not sure if it was ever there or not) an image title that wasn't in the YAML but is part of the SDR item record.

### Before
<img width="429" alt="Screen Shot 2021-12-10 at 10 26 52 AM" src="https://user-images.githubusercontent.com/101482/145616324-d470d508-90c0-4a13-8ed2-42fb822bfa9a.png">


### After
<img width="429" alt="Screen Shot 2021-12-10 at 10 26 33 AM" src="https://user-images.githubusercontent.com/101482/145616337-8c76c5fb-ac87-4497-b628-82f61d38b1fb.png">

