### PR TITLE
Update QR item labels for consistency

### DIFF
--- a/_data/experiences/adobe-and-apple.yaml
+++ b/_data/experiences/adobe-and-apple.yaml
@@ -8,7 +8,7 @@ more_info:
   - type: Collection
     text: Douglas Menuez photography collection, circa 1985 - 2008
     url: https://searchworks.stanford.edu/view/5628133
-  - type: Digital Exhibit
+  - type: Online Exhibit
     text: Douglas Menuez Photography Collection
     url: https://exhibits.stanford.edu/menuez
 attract_images:

--- a/_data/experiences/african-american-histories.yaml
+++ b/_data/experiences/african-american-histories.yaml
@@ -16,7 +16,7 @@ more_info:
   - type: Silicon Valley Archives
     text: The main webpage for the Silicon Valley Archives.
     url: https://library.stanford.edu/projects/silicon-valley-archives
-  - type: Digital exhibit
+  - type: Online exhibit
     text: "Silicon Genesis: Oral Histories of Semiconductor Technology"
     url: https://exhibits.stanford.edu/silicongenesis
 attract_images:

--- a/_data/experiences/silicon-genesis.yaml
+++ b/_data/experiences/silicon-genesis.yaml
@@ -11,7 +11,7 @@ local_file: local-media/20211130_2700x1800_SiliconGenesis_25mbps_wallscreen_29.9
 button_label: Silicon Genesis
 summary: The Silicon Genesis collection gathers together oral histories and interviews with the people who conceived, built and worked in the semiconductor industry centered in Silicon Valley since the 1950s. This project took shape in 1995 through the inspiration of Rob Walker (1935-2016), a Silicon Valley native and electrical engineer, who was involved with semiconductors since the 1960s at Fairchild, Intel and as a founder of LSI Logic. Walker, followed by industry veteran Rob Blair, have conducted these interviews, supplemented by a series produced by Craig Addision for SEMI (Semiconductor Equipment and Materials International) that were donated to the Silicon Valley Archives.
 more_info:
-  - type: Digital exhibit
+  - type: Online exhibit
     text: "Silicon Genesis: Oral Histories of Semiconductor Technology"
     url: https://exhibits.stanford.edu/silicongenesis
   - type: Online catalog


### PR DESCRIPTION
We were using both "Digital Exhibit" and "Online Exhibit" for Spotlight exhibit items. This PR changes them to all be "Online Exhibit".