### PR TITLE
Update attractor images for oral history experience index pages

### DIFF
--- a/_wallscreens/silicon-valley/oral-histories.html
+++ b/_wallscreens/silicon-valley/oral-histories.html
@@ -2,14 +2,13 @@
 layout: oral_history_index
 wallscreen: silicon-valley
 attract_images:
-  - images/experiences/silicon-genesis/attract-images/silicon-genesis-01.png
-  - images/experiences/silicon-genesis/attract-images/silicon-genesis-02.png
+  - images/experiences/african-american-histories/attract-images/african-american-histories-01.png
   - images/experiences/silicon-genesis/attract-images/silicon-genesis-03.png
+  - images/experiences/medical-technology/attract-images/medical-technology-05.png
   - images/experiences/silicon-genesis/attract-images/silicon-genesis-04.png
-  - images/experiences/silicon-genesis/attract-images/silicon-genesis-05.png
-  - images/experiences/silicon-genesis/attract-images/silicon-genesis-10.png
-  - images/experiences/silicon-genesis/attract-images/silicon-genesis-06.png
-  - images/experiences/silicon-genesis/attract-images/silicon-genesis-07.png
+  - images/experiences/african-american-histories/attract-images/african-american-histories-03.png
+  - images/experiences/medical-technology/attract-images/medical-technology-03.png
   - images/experiences/silicon-genesis/attract-images/silicon-genesis-08.png
-  - images/experiences/silicon-genesis/attract-images/silicon-genesis-09.png
+  - images/experiences/african-american-histories/attract-images/african-american-histories-05.png
+  - images/experiences/medical-technology/attract-images/medical-technology-01.png
 ---

--- a/_wallscreens/we-see-you/oral-histories.html
+++ b/_wallscreens/we-see-you/oral-histories.html
@@ -1,4 +1,14 @@
 ---
 layout: oral_history_index
 wallscreen: we-see-you
+attract_images:
+- images/experiences/african-american-histories/attract-images/african-american-histories-01.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-02.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-03.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-04.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-05.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-06.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-07.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-08.png
+- images/experiences/african-american-histories/attract-images/african-american-histories-09.png
 ---


### PR DESCRIPTION
Closes #310.

- Specifies AAH images for We See You oral history index page attractor grid (was empty)
- Updates the selection of images for the SVA oral history index page attractor (was using only images from one oral history instead of all three)


<img width="1292" alt="Screen Shot 2021-12-14 at 4 30 33 PM" src="https://user-images.githubusercontent.com/101482/146095875-9167d6ed-e23c-4234-a1fd-c8e0359a572c.png">

---

<img width="1292" alt="Screen Shot 2021-12-14 at 4 30 56 PM" src="https://user-images.githubusercontent.com/101482/146095898-9c04c233-db0f-4475-b088-9e41f0bfbe01.png">

