### PR TITLE
Disable hover and focus styles on touchscreens

### DIFF
--- a/_scss/wallscreens/_buttons.scss
+++ b/_scss/wallscreens/_buttons.scss
@@ -24,12 +24,14 @@ button, .button {
   padding: $btn-padding $btn-padding-lg;
   text-decoration: none;
 
-  &:hover {
-    color: $su-color-black-true;
-  }
+  @media (hover: hover) {
+    &:hover {
+      color: $su-color-black-true;
+    }
 
-  &:focus {
-    box-shadow: $btn-focus-box-shadow;
+    &:focus {
+      box-shadow: $btn-focus-box-shadow;
+    }
   }
 
   &:active {


### PR DESCRIPTION
Here's what I found investigating #289:

- Our `:hover` and `:focus` styles don't need to be applied when on a wallscreen, since those devices can't hover, and the focus style will "stick" after touching a button which I don't think is what we want. I moved them behind a media query so they'll still work on non-touch devices.
- Doing this made the actual effect of the `:active` style more apparent: the `box-shadow` changes in a way that creates a natural "button depressed" effect, which actually looks OK to me as-is (but @ggeisler should probably take a look and confirm).
- In quite a few places, the `:active` style doesn't matter, because the page load transition actually happens before we get to see any changes to the button! This seems to happen to everything in the interaction area, as well as "start experience" button. The button to open/close the modal doesn't reload the page, but it also doesn't show the `:active` style...maybe because focus is being moved? Not sure what's going on there.
- The "next/previous" buttons do seem to show the `:active` style well, which makes sense because they don't cause the page to reload: we just swap in some different content around them. So, if we're OK only showing this style on these buttons, we might not need to do any more here.
